### PR TITLE
Fix: Use fixed max Wounds for characters without Hardy

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/Character.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/Character.kt
@@ -233,6 +233,8 @@ data class Character(
                 if (hasHardyTalent) {
                     return manualMaxWounds + tb
                 }
+
+                return manualMaxWounds
             }
 
             val baseWounds = Wounds.calculateMax(size ?: Size.AVERAGE, characteristics)


### PR DESCRIPTION
Closes https://github.com/fmasa/wfrp-master/issues/6

This was a bug that caused automatic calculation of maximum Wounds for characters without checked Hardy checkbox.