### PR TITLE
Use Int instead of UInt

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/combat/ArmourCard.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/combat/ArmourCard.kt
@@ -43,7 +43,7 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 fun ArmourCard(
     armour: Armour,
     armourPieces: Map<HitLocation, List<WornArmourPiece>>,
-    toughnessBonus: UInt,
+    toughnessBonus: Int,
     onTrappingClick: (InventoryItem) -> Unit,
 ) {
     UserTipCard(UserTip.ARMOUR_TRAPPINGS, Modifier.padding(horizontal = 8.dp))
@@ -71,7 +71,7 @@ fun ArmourCard(
                     LocalStrings.current.characteristics.toughnessBonusShortcut,
                     Modifier.padding(end = Spacing.medium),
                 )
-                Points(toughnessBonus.toInt())
+                Points(toughnessBonus)
             }
 
             Row(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/combat/CharacterCombatScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/combat/CharacterCombatScreenModel.kt
@@ -26,11 +26,11 @@ class CharacterCombatScreenModel(
     private val characterFlow = characterRepository.getLive(characterId)
         .right()
     private val strengthBonusFlow = characterFlow
-        .map { it.characteristics.strengthBonus.toUInt() }
+        .map { it.characteristics.strengthBonus }
         .distinctUntilChanged()
 
-    val toughnessBonus: Flow<UInt> = characterFlow
-        .map { it.characteristics.toughnessBonus.toUInt() }
+    val toughnessBonus: Flow<Int> = characterFlow
+        .map { it.characteristics.toughnessBonus }
         .distinctUntilChanged()
 
     val equippedWeapons: Flow<List<Pair<WeaponEquip, List<EquippedWeapon>>>> =
@@ -95,7 +95,7 @@ class CharacterCombatScreenModel(
 
     private fun equippedWeaponOrNull(
         trapping: InventoryItem,
-        strengthBonus: UInt
+        strengthBonus: Int
     ): EquippedWeapon? {
         val type = trapping.trappingType
 
@@ -111,7 +111,7 @@ class CharacterCombatScreenModel(
             equip = equip,
             damage = type.damage.calculate(
                 strengthBonus = strengthBonus,
-                successLevels = 0.toUInt(),
+                successLevels = 0,
             )
         )
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/effects/SwarmWoundsModification.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/effects/SwarmWoundsModification.kt
@@ -12,7 +12,7 @@ class SwarmWoundsModification: CharacterEffect {
 
         return character.modifyWounds(
             modifiers.copy(
-                afterMultiplier = modifiers.afterMultiplier * 5.toUInt(),
+                afterMultiplier = modifiers.afterMultiplier * 5,
             )
         )
     }
@@ -26,7 +26,7 @@ class SwarmWoundsModification: CharacterEffect {
 
         return character.modifyWounds(
             modifiers.copy(
-                afterMultiplier = modifiers.afterMultiplier / 5.toUInt(),
+                afterMultiplier = modifiers.afterMultiplier / 5,
             )
         )
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/spells/dialog/NonCompendiumSpellForm.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/spells/dialog/NonCompendiumSpellForm.kt
@@ -136,7 +136,7 @@ private class NonCompendiumSpellFormData(
         range = range.value,
         target = target.value,
         duration = duration.value,
-        castingNumber = castingNumber.value.toUInt(),
+        castingNumber = castingNumber.value.toInt(),
         effect = effect.value,
     )
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Spell.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Spell.kt
@@ -17,7 +17,7 @@ data class Spell(
     val range: String,
     val target: String,
     val duration: String,
-    val castingNumber: UInt,
+    val castingNumber: Int,
     val effect: String,
     val lore: String,
 ) : CompendiumItem<Spell>() {
@@ -32,6 +32,7 @@ data class Spell(
 
     init {
         require(name.isNotBlank()) { "Name must not be blank" }
+        require(castingNumber >= 0) { "Casting number cannot be negative" }
         require(name.length <= NAME_MAX_LENGTH) { "Name must be shorter than $NAME_MAX_LENGTH" }
         require(range.length <= RANGE_MAX_LENGTH) { "Range must be shorter than $RANGE_MAX_LENGTH" }
         require(target.length <= TARGET_MAX_LENGTH) { "Target must be shorter than $TARGET_MAX_LENGTH" }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/grammars/SpellListGrammar.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/grammars/SpellListGrammar.kt
@@ -33,7 +33,7 @@ class SpellListGrammar(private val loreName: String) : Grammar<List<Spell>>() {
         Spell(
             id = UUID.randomUUID(),
             name = cleanupName(parts[0]),
-            castingNumber = parts[1].toUInt(),
+            castingNumber = parts[1].toInt(),
             range = extractTextValue(range),
             target = extractTextValue(target),
             duration = extractTextValue(duration),

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/tabs/SpellCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/tabs/SpellCompendiumTab.kt
@@ -95,7 +95,7 @@ private data class SpellFormData(
         range = range.value,
         target = target.value,
         duration = duration.value,
-        castingNumber = castingNumber.value.toUInt(),
+        castingNumber = castingNumber.value.toInt(),
         effect = effect.value,
     )
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/Damage.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/Damage.kt
@@ -5,4 +5,8 @@ import kotlin.jvm.JvmInline
 
 @JvmInline
 @Immutable
-value class Damage(val value: UInt)
+value class Damage(val value: Int) {
+    init {
+        require(value >= 0) { "Damage cannot be negative" }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/WoundsModifiers.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/WoundsModifiers.kt
@@ -9,11 +9,11 @@ import kotlinx.serialization.Serializable
 @Parcelize
 @Immutable
 data class WoundsModifiers(
-    val afterMultiplier: UInt = 1.toUInt(),
+    val afterMultiplier: Int = 1,
     val extraToughnessBonusMultiplier: Int = 0,
 ) : Parcelable {
     init {
         require(extraToughnessBonusMultiplier >= 0)
-        require(afterMultiplier >= 1.toUInt())
+        require(afterMultiplier >= 1)
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/combat/Advantage.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/combat/Advantage.kt
@@ -7,7 +7,11 @@ import kotlin.jvm.JvmInline
 @JvmInline
 @Immutable
 @Serializable
-value class Advantage(val value: UInt): Comparable<Advantage> {
+value class Advantage(val value: Int): Comparable<Advantage> {
+
+    init {
+        require(value >= 0) { "Advantage cannot be negative" }
+    }
 
     operator fun inc(): Advantage = Advantage(value.inc())
 
@@ -23,6 +27,6 @@ value class Advantage(val value: UInt): Comparable<Advantage> {
     override fun toString(): String = value.toString()
 
     companion object {
-        val ZERO = Advantage((0).toUInt())
+        val ZERO = Advantage(0)
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/settings/Settings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/settings/Settings.kt
@@ -34,14 +34,13 @@ value class AdvantageCapExpression(val value: String) : Parcelable {
 
     fun calculate(characteristics: Stats): Advantage {
         if (value == "") {
-            return Advantage(UInt.MAX_VALUE)
+            return Advantage(Int.MAX_VALUE)
         }
 
         return Advantage(
             Expression.fromString(value, constantsFrom(characteristics))
                 .evaluate()
                 .coerceAtLeast(0)
-                .toUInt()
         )
     }
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/spells/Spell.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/spells/Spell.kt
@@ -20,18 +20,19 @@ data class Spell(
     val range: String,
     val target: String,
     val duration: String,
-    val castingNumber: UInt,
+    val castingNumber: Int,
     val effect: String,
     val memorized: Boolean = true, // TODO: Remove default value and migrate stored data
 ) : CharacterItem {
 
 
-    val effectiveCastingNumber: UInt get() = if (memorized)
+    val effectiveCastingNumber: Int get() = if (memorized)
         castingNumber
-    else castingNumber * 2.toUInt()
+    else castingNumber * 2
 
     init {
         require(name.isNotBlank()) { "Name must not be blank" }
+        require(castingNumber >= 0) { "Casting number cannot be negative" }
         require(name.length <= NAME_MAX_LENGTH) { "Name must be shorter than $NAME_MAX_LENGTH" }
         require(range.length <= RANGE_MAX_LENGTH) { "Range must be shorter than $RANGE_MAX_LENGTH" }
         require(target.length <= TARGET_MAX_LENGTH) { "Target must be shorter than $TARGET_MAX_LENGTH" }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/trappings/DamageExpression.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/trappings/DamageExpression.kt
@@ -28,13 +28,13 @@ value class DamageExpression(val value: String) : Parcelable {
         STRENGTH_BONUS("SB")
     }
 
-    fun calculate(strengthBonus: UInt, successLevels: UInt): Damage {
+    fun calculate(strengthBonus: Int, successLevels: Int): Damage {
         val damage = Expression.fromString(
             value,
-            mapOf(Constant.STRENGTH_BONUS.value to strengthBonus.toInt()),
+            mapOf(Constant.STRENGTH_BONUS.value to strengthBonus),
         ).evaluate()
 
-        return Damage(damage.toUInt() + successLevels)
+        return Damage(damage + successLevels)
     }
 
     companion object {

--- a/common/src/commonTest/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/grammars/SpellListGrammarTest.kt
+++ b/common/src/commonTest/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/grammars/SpellListGrammarTest.kt
@@ -56,7 +56,7 @@ class SpellListGrammarTest {
                 Spell(
                     id = result[0].id,
                     name = "Push ’em",
-                    castingNumber = 6.toUInt(),
+                    castingNumber = 6,
                     range = "You",
                     target = "You",
                     duration = "Instant",
@@ -73,7 +73,7 @@ class SpellListGrammarTest {
                 Spell(
                     id = result[1].id,
                     name = "Teleport",
-                    castingNumber = 5.toUInt(),
+                    castingNumber = 5,
                     range = "You",
                     target = "You",
                     duration = "Instant",
@@ -88,7 +88,7 @@ class SpellListGrammarTest {
                 Spell(
                     id = result[2].id,
                     name = "Terrifying",
-                    castingNumber = 7.toUInt(),
+                    castingNumber = 7,
                     range = "You",
                     target = "You",
                     duration = "Willpower Bonus Rounds",
@@ -98,7 +98,7 @@ class SpellListGrammarTest {
                 Spell(
                     id = result[3].id,
                     name = "Ward",
-                    castingNumber = 5.toUInt(),
+                    castingNumber = 5,
                     range = "You",
                     target = "You",
                     duration = "Willpower Bonus Rounds",


### PR DESCRIPTION
I originally used `UInt` to mark the intent that the value should never be negative, but `UInt` proved to be more error-prone than Int.

`UInt` makes i.e. subtracting low values tricky, as `(a - b).coerceAtLeast(0)` for `a = 2` and `b = 3` wouldn't evaluate to `0`, but to `UInt.MAX_VALUE` due to underflow. So using `UInt` actually makes working with non-negative numbers harder and leads to subtle bugs such as #6. 