### PR TITLE
Remove CombatScreen auto-close

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/CombatScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/CombatScreenModel.kt
@@ -73,10 +73,6 @@ class CombatScreenModel(
         .mapLatest { EncounterId(partyId, it.encounterId) }
         .distinctUntilChanged()
 
-    val isCombatActive: Flow<Boolean> = party
-        .mapLatest { it.activeCombat != null }
-        .distinctUntilChanged()
-
     val turn: Flow<Int> = combatFlow
         .mapLatest { it.getTurn() }
         .distinctUntilChanged()

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -409,7 +409,7 @@ data class CombatStrings(
 @Immutable
 data class CombatMessageStrings(
     val combatInProgress: String = "Combat is in progress",
-    val noActiveCombat: String = "There is no active combat",
+    val waitingForCombat: String = "Waiting for Combat…",
 )
 
 @Immutable


### PR DESCRIPTION
Sometimes when Party refresh is too slow, GM is sent to CombatScreen
and immediately sent back, because there is no active combat yet.