### PR TITLE
Polish rulebook compendium import

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CompendiumImportScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CompendiumImportScreen.kt
@@ -39,6 +39,7 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.Subtitle
 import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import java.lang.OutOfMemoryError
 
 class CompendiumImportScreen(
@@ -88,27 +89,29 @@ class CompendiumImportScreen(
         val snackbarHolder = LocalPersistentSnackbarHolder.current
         val fileChooser = rememberFileChooser { result ->
             result.mapCatching { file ->
-                importState = ImportDialogState.LoadingItems
+                coroutineScope {
+                    importState = ImportDialogState.LoadingItems
 
-                val importer = RulebookCompendiumImporter(file.stream)
+                    val importer = RulebookCompendiumImporter(file.stream)
 
-                val skills = async { importer.importSkills() }
-                val talents = async { importer.importTalents() }
-                val spells = async { importer.importSpells() }
-                val blessings = async { importer.importBlessings() }
-                val miracles = async { importer.importMiracles() }
-                val traits = async { importer.importTraits() }
-                val careers = async { importer.importCareers() }
+                    val skills = async { importer.importSkills() }
+                    val talents = async { importer.importTalents() }
+                    val spells = async { importer.importSpells() }
+                    val blessings = async { importer.importBlessings() }
+                    val miracles = async { importer.importMiracles() }
+                    val traits = async { importer.importTraits() }
+                    val careers = async { importer.importCareers() }
 
-                importState = ImportDialogState.PickingItemsToImport(
-                    skills.await(),
-                    talents.await(),
-                    spells.await(),
-                    blessings.await(),
-                    miracles.await(),
-                    traits.await(),
-                    careers.await(),
-                )
+                    importState = ImportDialogState.PickingItemsToImport(
+                        skills.await(),
+                        talents.await(),
+                        spells.await(),
+                        blessings.await(),
+                        miracles.await(),
+                        traits.await(),
+                        careers.await(),
+                    )
+                }
             }.onFailure {
                 Napier.e(it.toString(), it)
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CompendiumImportScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CompendiumImportScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
@@ -31,6 +32,7 @@ import cz.frantisekmasa.wfrp_master.common.core.shared.rememberFileChooser
 import cz.frantisekmasa.wfrp_master.common.core.shared.rememberUrlOpener
 import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.BackButton
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
 import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
 import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.Subtitle
@@ -123,7 +125,7 @@ class CompendiumImportScreen(
         }
 
         Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize().padding(Spacing.bodyPadding),
             verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -466,7 +466,12 @@ data class CompendiumStrings(
     val buttonImport: String = "Import",
     val buttonImportRulebook: String = "Import rulebook PDF",
     val iconAddCompendiumItem: String = "Add compendium item",
-    val importPrompt: String = "Import compendium from official WFRP rulebook.",
+    val importPrompt: AnnotatedString = buildAnnotatedString {
+        append("Import compendium from official WFRP Rulebook PDF.")
+        withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
+            append("Only the latest version of English Rulebook is supported.")
+        }
+    },
     val messages: CompendiumMessageStrings = CompendiumMessageStrings(),
     val pickPromptCareers: String = "Select which careers you want to import.",
     val pickPromptSkills: String = "Select which skills you want to import.",


### PR DESCRIPTION
- Fixes error handling when importing Compendium (instead of crash, error message is shown)
- Mention that only the latest version of English Rulebook PDF is supported (there were many crash reports of people trying to import localized versions of Rulebook, which is not supported)