### PR TITLE
Fix reordering of combatants

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/primitives/DraggableListFor.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/primitives/DraggableListFor.kt
@@ -47,7 +47,7 @@ fun <T> DraggableListFor(
         content = {
             items.forEachIndexed { index, item ->
                 Box(
-                    Modifier.pointerInput(placeableHeights, itemSpacingPx, coroutineScope) {
+                    Modifier.pointerInput(placeableHeights, itemSpacingPx, coroutineScope, items) {
                         detectDragGesturesAfterLongPress(
                             onDragStart = {
                                 coroutineScope.launch { dragY.snapTo(0f) }


### PR DESCRIPTION
Previously reordering combatants would reset the Wounds for NPCs that were multiplied and would break subsequent reorderings altogether.