### PR TITLE
Compendium import & export

### DIFF
--- a/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/shared/FileChooser.kt
+++ b/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/shared/FileChooser.kt
@@ -11,10 +11,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.InputStream
+import java.io.OutputStream
 
 @Composable
 actual fun rememberFileChooser(
-    onFileChoose: suspend CoroutineScope.(Result<File>) -> Unit
+    onFileChoose: suspend CoroutineScope.(Result<ReadableFile>) -> Unit
 ): FileChooser {
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -31,7 +32,7 @@ actual fun rememberFileChooser(
             onFileChoose(
                 if (inputStream == null)
                     Result.failure(Exception("Could not open input stream"))
-                else Result.success(File(inputStream))
+                else Result.success(ReadableFile(inputStream))
             )
         }
     }
@@ -39,10 +40,61 @@ actual fun rememberFileChooser(
     return AndroidFileChooser(launcher)
 }
 
-actual class File(
+@Composable
+actual fun rememberFileSaver(
+    type: FileType,
+    defaultFileName: String,
+    onLocationChoose: suspend CoroutineScope.(Result<WriteableFile>) -> Unit,
+): FileSaver {
+    val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
+
+    val contract = ActivityResultContracts.CreateDocument(
+        when (type) {
+            FileType.IMAGE -> "image/jpeg"
+            FileType.PDF -> "application/pdf"
+            FileType.JSON -> "application/json"
+        }
+    )
+
+    val launcher = rememberLauncherForActivityResult(contract) { uri ->
+        coroutineScope.launch(Dispatchers.IO) {
+            if (uri == null) {
+                onLocationChoose(Result.failure(Exception("URI not selected")))
+                return@launch
+            }
+
+            val outputStream = context.contentResolver.openOutputStream(uri)
+
+            onLocationChoose(
+                if (outputStream == null)
+                    Result.failure(Exception("Could not open output stream"))
+                else Result.success(WriteableFile(outputStream))
+            )
+        }
+    }
+
+    return FileSaver {
+        launcher.launch(defaultFileName)
+    }
+}
+
+actual class ReadableFile(
     actual val stream: InputStream
 ) {
     actual fun readBytes(): ByteArray = stream.readBytes()
+}
+
+actual class WriteableFile(
+    private val stream: OutputStream
+) {
+    actual fun writeBytes(bytes: ByteArray) {
+        stream.write(bytes)
+    }
+
+    actual fun close() {
+        stream.close()
+    }
 }
 
 class AndroidFileChooser(
@@ -53,6 +105,7 @@ class AndroidFileChooser(
             when (type) {
                 FileType.IMAGE -> "image/*"
                 FileType.PDF -> "application/pdf"
+                FileType.JSON -> "application/json"
             }
         )
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CompendiumImportScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CompendiumImportScreen.kt
@@ -110,6 +110,7 @@ class CompendiumImportScreen(
                         miracles.await(),
                         traits.await(),
                         careers.await(),
+                        replaceExistingByDefault = false,
                     )
                 }
             }.onFailure {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CompendiumScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CompendiumScreen.kt
@@ -36,17 +36,17 @@ import cz.frantisekmasa.wfrp_master.common.compendium.tabs.TalentCompendiumTab
 import cz.frantisekmasa.wfrp_master.common.compendium.tabs.TraitCompendiumTab
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.CompendiumItem
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
-import cz.frantisekmasa.wfrp_master.common.core.shared.IO
 import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.BackButton
 import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.DialogState
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
+import cz.frantisekmasa.wfrp_master.common.core.ui.menu.DropdownMenuItem
 import cz.frantisekmasa.wfrp_master.common.core.ui.menu.WithContextMenu
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.ContextMenu
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.OptionsAction
 import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.Subtitle
-import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.TopBarAction
 import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.tabs.TabPager
 import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.tabs.tab
 import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
@@ -93,10 +93,25 @@ class CompendiumScreen(
             },
             navigationIcon = { BackButton() },
             actions = {
-                TopBarAction(
-                    text = strings.buttonImport,
-                    onClick = { navigator.push(CompendiumImportScreen(partyId)) }
-                )
+                OptionsAction {
+                    DropdownMenuItem(
+                        onClick = { navigator.push(RulebookCompendiumImportScreen(partyId)) }
+                    ) {
+                        Text(strings.buttonImportFromRulebook)
+                    }
+
+                    DropdownMenuItem(
+                        onClick = { navigator.push(JsonCompendiumImportScreen(partyId)) }
+                    ) {
+                        Text(strings.buttonImportFile)
+                    }
+
+                    DropdownMenuItem(
+                        onClick = { navigator.push(JsonCompendiumExportScreen(partyId)) }
+                    ) {
+                        Text(strings.buttonExportFile)
+                    }
+                }
             }
         )
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/ImportDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/ImportDialog.kt
@@ -290,7 +290,7 @@ private fun <T : CompendiumItem<T>> ItemPicker(
 }
 
 @Immutable
-internal sealed class ImportDialogState {
+sealed class ImportDialogState {
     @Immutable
     object LoadingItems : ImportDialogState()
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/ImportDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/ImportDialog.kt
@@ -221,7 +221,7 @@ private fun <T : CompendiumItem<T>> ItemPicker(
                                         onSave(
                                             items
                                                 .asSequence()
-                                                .filter { selectedItems.contains(it.id) }
+                                                .filter { selectedItems[it.id] == true }
                                                 .map {
                                                     val existingItem = existingItemsByName[it.name]
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/ImportDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/ImportDialog.kt
@@ -33,7 +33,6 @@ import cz.frantisekmasa.wfrp_master.common.compendium.domain.Talent
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Trait
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.CompendiumItem
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
-import cz.frantisekmasa.wfrp_master.common.core.shared.IO
 import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.CloseButton
 import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.FullScreenDialog
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
@@ -61,7 +60,6 @@ internal fun ImportDialog(
             is ImportDialogState.PickingItemsToImport -> ImportedItemsPicker(
                 screenModel = screenModel,
                 state = state,
-                partyId = partyId,
                 onDismissRequest = onDismissRequest,
                 onComplete = onComplete,
             )
@@ -72,7 +70,6 @@ internal fun ImportDialog(
 @Composable
 private fun ImportedItemsPicker(
     screenModel: CompendiumScreenModel,
-    partyId: PartyId,
     state: ImportDialogState.PickingItemsToImport,
     onDismissRequest: () -> Unit,
     onComplete: () -> Unit,
@@ -90,6 +87,7 @@ private fun ImportedItemsPicker(
                 onContinue = { screen = ItemsScreen.TALENTS },
                 onClose = onDismissRequest,
                 existingItems = screenModel.skills,
+                replaceExistingByDefault = state.replaceExistingByDefault,
             )
         }
         ItemsScreen.TALENTS -> {
@@ -100,6 +98,7 @@ private fun ImportedItemsPicker(
                 onContinue = { screen = ItemsScreen.SPELLS },
                 onClose = onDismissRequest,
                 existingItems = screenModel.talents,
+                replaceExistingByDefault = state.replaceExistingByDefault,
             )
         }
         ItemsScreen.SPELLS -> {
@@ -110,6 +109,7 @@ private fun ImportedItemsPicker(
                 onContinue = { screen = ItemsScreen.BLESSINGS },
                 onClose = onDismissRequest,
                 existingItems = screenModel.spells,
+                replaceExistingByDefault = state.replaceExistingByDefault,
             )
         }
         ItemsScreen.BLESSINGS -> {
@@ -120,6 +120,7 @@ private fun ImportedItemsPicker(
                 onContinue = { screen = ItemsScreen.MIRACLES },
                 onClose = onDismissRequest,
                 existingItems = screenModel.blessings,
+                replaceExistingByDefault = state.replaceExistingByDefault,
             )
         }
         ItemsScreen.MIRACLES -> {
@@ -130,6 +131,7 @@ private fun ImportedItemsPicker(
                 onContinue = { screen = ItemsScreen.TRAITS },
                 onClose = onDismissRequest,
                 existingItems = screenModel.miracles,
+                replaceExistingByDefault = state.replaceExistingByDefault,
             )
         }
         ItemsScreen.TRAITS -> {
@@ -140,6 +142,7 @@ private fun ImportedItemsPicker(
                 onContinue = { screen = ItemsScreen.CAREERS },
                 onClose = onDismissRequest,
                 existingItems = screenModel.traits,
+                replaceExistingByDefault = state.replaceExistingByDefault,
             )
         }
         ItemsScreen.CAREERS -> {
@@ -150,6 +153,7 @@ private fun ImportedItemsPicker(
                 onContinue = onComplete,
                 onClose = onDismissRequest,
                 existingItems = screenModel.careers,
+                replaceExistingByDefault = state.replaceExistingByDefault,
             )
         }
     }
@@ -163,6 +167,7 @@ private fun <T : CompendiumItem<T>> ItemPicker(
     onContinue: () -> Unit,
     existingItems: Flow<List<T>>,
     items: List<T>,
+    replaceExistingByDefault: Boolean,
 ) {
     val existingItemsList = existingItems.collectWithLifecycle(null).value
 
@@ -179,12 +184,13 @@ private fun <T : CompendiumItem<T>> ItemPicker(
         return
     }
 
-    val existingItemNames = remember(existingItemsList) {
-        existingItemsList.map { it.name }.toHashSet()
+    val existingItemsByName = remember(existingItemsList) {
+        existingItemsList.associateBy { it.name }
     }
 
-    val selectedItems = remember(items, existingItemNames) {
-        items.map { it.id to !existingItemNames.contains(it.name) }.toMutableStateMap()
+    val selectedItems = remember(items, existingItemsByName, replaceExistingByDefault) {
+        items.map { it.id to (replaceExistingByDefault || it.name !in existingItemsByName) }
+            .toMutableStateMap()
     }
     val atLeastOneSelected = selectedItems.containsValue(true)
 
@@ -212,7 +218,20 @@ private fun <T : CompendiumItem<T>> ItemPicker(
 
                                 if (atLeastOneSelected) {
                                     withContext(Dispatchers.IO) {
-                                        onSave(items.filter { selectedItems.contains(it.id) })
+                                        onSave(
+                                            items
+                                                .asSequence()
+                                                .filter { selectedItems.contains(it.id) }
+                                                .map {
+                                                    val existingItem = existingItemsByName[it.name]
+
+                                                    if (existingItem != null)
+                                                        it.replace(existingItem)
+                                                    else it
+                                                }
+                                                .distinctBy { it.id }
+                                                .toList()
+                                        )
                                     }
                                 }
 
@@ -253,8 +272,14 @@ private fun <T : CompendiumItem<T>> ItemPicker(
                                 onValueChange = { selectedItems[item.id] = it },
                             ),
                             text = { Text(item.name) },
-                            secondaryText = if (existingItemNames.contains(item.name)) {
-                                { Text(strings.compendium.messages.itemAlreadyExists) }
+                            secondaryText = if (item.name in existingItemsByName) {
+                                {
+                                    Text(
+                                        if (selectedItems[item.id] == true)
+                                            strings.compendium.messages.willReplaceExistingItem
+                                        else strings.compendium.messages.itemAlreadyExists
+                                    )
+                                }
                             } else null
                         )
                     }
@@ -278,6 +303,7 @@ internal sealed class ImportDialogState {
         val miracles: List<Miracle>,
         val traits: List<Trait>,
         val careers: List<Career>,
+        val replaceExistingByDefault: Boolean,
     ) : ImportDialogState()
 }
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/ImportFileChooser.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/ImportFileChooser.kt
@@ -1,0 +1,58 @@
+package cz.frantisekmasa.wfrp_master.common.compendium
+
+import androidx.compose.material.SnackbarDuration
+import androidx.compose.runtime.Composable
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.CompendiumImporter
+import cz.frantisekmasa.wfrp_master.common.core.shared.FileChooser
+import cz.frantisekmasa.wfrp_master.common.core.shared.ReadableFile
+import cz.frantisekmasa.wfrp_master.common.core.shared.rememberFileChooser
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+@Composable
+fun ImportFileChooser(
+    onStateChange: (ImportDialogState?) -> Unit,
+    importerFactory: suspend (ReadableFile) -> CompendiumImporter,
+    errorMessageFactory: (Throwable) -> String,
+): FileChooser {
+    val snackbarHolder = LocalPersistentSnackbarHolder.current
+
+    return rememberFileChooser { result ->
+        result.mapCatching { file ->
+            coroutineScope {
+                onStateChange(ImportDialogState.LoadingItems)
+
+                val importer = importerFactory(file)
+
+                val skills = async { importer.importSkills() }
+                val talents = async { importer.importTalents() }
+                val spells = async { importer.importSpells() }
+                val blessings = async { importer.importBlessings() }
+                val miracles = async { importer.importMiracles() }
+                val traits = async { importer.importTraits() }
+                val careers = async { importer.importCareers() }
+
+                onStateChange(
+                    ImportDialogState.PickingItemsToImport(
+                        skills.await(),
+                        talents.await(),
+                        spells.await(),
+                        blessings.await(),
+                        miracles.await(),
+                        traits.await(),
+                        careers.await(),
+                        replaceExistingByDefault = false,
+                    )
+                )
+            }
+        }.onFailure {
+            Napier.e(it.toString(), it)
+
+            snackbarHolder.showSnackbar(errorMessageFactory(it), SnackbarDuration.Long,)
+
+            onStateChange(null)
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/JsonCompendiumExportScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/JsonCompendiumExportScreen.kt
@@ -1,0 +1,106 @@
+package cz.frantisekmasa.wfrp_master.common.compendium
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.Scaffold
+import androidx.compose.material.SnackbarDuration
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import cafe.adriel.voyager.core.screen.Screen
+import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
+import cz.frantisekmasa.wfrp_master.common.core.shared.FileType
+import cz.frantisekmasa.wfrp_master.common.core.shared.rememberFileSaver
+import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.BackButton
+import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.Subtitle
+import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
+import io.github.aakira.napier.Napier
+
+class JsonCompendiumExportScreen(
+    private val partyId: PartyId,
+) : Screen {
+    @Composable
+    override fun Content() {
+        val screenModel: CompendiumScreenModel = rememberScreenModel(arg = partyId)
+        val party = screenModel.party.collectWithLifecycle(null).value
+
+        if (party == null) {
+            FullScreenProgress()
+            return
+        }
+
+        Scaffold(topBar = { TopBar(party.name) }) {
+            MainContainer(party.name, screenModel)
+        }
+    }
+
+    @Composable
+    private fun TopBar(partyName: String) {
+        TopAppBar(
+            title = {
+                Column {
+                    Text(LocalStrings.current.compendium.titleExportCompendium)
+                    Subtitle(partyName)
+                }
+            },
+            navigationIcon = { BackButton() },
+        )
+    }
+
+    @Composable
+    private fun MainContainer(partyName: String, screenModel: CompendiumScreenModel) {
+        val strings = LocalStrings.current.compendium
+        val snackbarHolder = LocalPersistentSnackbarHolder.current
+        var exporting by remember { mutableStateOf(false) }
+
+        val fileSaver = rememberFileSaver(
+            FileType.JSON,
+            "$partyName-compendium",
+        ) { result ->
+            result.mapCatching { file ->
+                try {
+                    exporting = true
+                    val json = screenModel.buildExportJson()
+                    file.writeBytes(json.toByteArray())
+                } finally {
+                    file.close()
+                    exporting = false
+                }
+            }.onFailure {
+                Napier.e(it.toString(), it)
+
+                snackbarHolder.showSnackbar(strings.messages.exportFailed, SnackbarDuration.Long)
+
+                exporting = false
+            }
+        }
+
+        if (exporting) {
+            FullScreenProgress()
+            return
+        }
+
+        Box(
+            modifier = Modifier.fillMaxSize().padding(Spacing.bodyPadding),
+            contentAlignment = Alignment.Center,
+        ) {
+            Button(onClick = { fileSaver.selectLocation() }) {
+                Text(strings.buttonExport.uppercase())
+            }
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/RulebookCompendiumImportScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/RulebookCompendiumImportScreen.kt
@@ -1,0 +1,128 @@
+package cz.frantisekmasa.wfrp_master.common.compendium
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.RulebookCompendiumImporter
+import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
+import cz.frantisekmasa.wfrp_master.common.core.shared.FileType
+import cz.frantisekmasa.wfrp_master.common.core.shared.rememberUrlOpener
+import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.BackButton
+import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.Subtitle
+import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
+import java.lang.OutOfMemoryError
+
+class RulebookCompendiumImportScreen(
+    private val partyId: PartyId,
+) : Screen {
+    @Composable
+    override fun Content() {
+        val screenModel: CompendiumScreenModel = rememberScreenModel(arg = partyId)
+        Scaffold(topBar = { TopBar(screenModel) }) {
+            MainContainer()
+        }
+    }
+
+    @Composable
+    private fun TopBar(screenModel: CompendiumScreenModel) {
+        TopAppBar(
+            title = {
+                Column {
+                    Text(LocalStrings.current.compendium.titleImportCompendium)
+                    screenModel.party.collectWithLifecycle(null).value?.let {
+                        Subtitle(it.name)
+                    }
+                }
+            },
+            navigationIcon = { BackButton() },
+        )
+    }
+
+    @Composable
+    private fun MainContainer() {
+        val strings = LocalStrings.current.compendium
+
+        var importState by remember { mutableStateOf<ImportDialogState?>(null) }
+
+        importState?.let {
+            val navigator = LocalNavigator.currentOrThrow
+
+            ImportDialog(
+                state = it,
+                partyId = partyId,
+                onDismissRequest = { importState = null },
+                onComplete = navigator::pop,
+                screenModel = rememberScreenModel(arg = partyId)
+            )
+        }
+
+        val fileChooser = ImportFileChooser(
+            onStateChange = { importState = it },
+            importerFactory = { RulebookCompendiumImporter(it.stream) },
+            errorMessageFactory = {
+                when (it) {
+                    is OutOfMemoryError -> strings.messages.outOfMemory
+                    else -> strings.messages.rulebookImportFailed
+                }
+            }
+        )
+
+        Column(
+            modifier = Modifier.fillMaxSize().padding(Spacing.bodyPadding),
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                strings.rulebookImportPrompt,
+                textAlign = TextAlign.Center,
+            )
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = { fileChooser.open(FileType.PDF) }) {
+                    Text(strings.buttonImportRulebook.uppercase())
+                }
+
+                val urlOpener = rememberUrlOpener()
+
+                OutlinedButton(
+                    onClick = {
+                        urlOpener.open(strings.rulebookStoreLink, isGooglePlayLink = false)
+                    }
+                ) {
+                    Text(strings.buttonBuy.uppercase())
+                }
+            }
+
+            Text(
+                strings.assurance,
+                color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.body2
+            )
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerDetailScreen.kt
@@ -123,6 +123,7 @@ class CareerDetailScreen(
         }
 
         val isGameMaster = LocalUser.current.id == party.gameMasterId
+        val levelNames = remember(career) { career.levels.map { it.name }.toSet() }
 
         when (dialogState) {
             LevelDialogState.Closed -> {}
@@ -132,6 +133,7 @@ class CareerDetailScreen(
                     existingLevel = null,
                     onSave = { screenModel.saveLevel(partyId, career.id, it) },
                     onDismissRequest = { setDialogState(LevelDialogState.Closed) },
+                    existingLevelNames = levelNames,
                 )
             }
             is LevelDialogState.EditLevel -> {
@@ -140,6 +142,7 @@ class CareerDetailScreen(
                     existingLevel = dialogState.level,
                     onSave = { screenModel.saveLevel(partyId, career.id, it) },
                     onDismissRequest = { setDialogState(LevelDialogState.Closed) },
+                    existingLevelNames = levelNames - dialogState.level.name,
                 )
             }
         }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Blessing.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Blessing.kt
@@ -36,5 +36,7 @@ data class Blessing(
         effect.requireMaxLength(EFFECT_MAX_LENGTH, "effect")
     }
 
+    override fun replace(original: Blessing) = copy(id = original.id)
+
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Career.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Career.kt
@@ -31,6 +31,9 @@ data class Career(
         require(name.isNotBlank() && name.length <= NAME_MAX_LENGTH)
         require(description.length <= DESCRIPTION_MAX_LENGTH)
         require(races.isNotEmpty())
+        require(levels.map { it.name }.toSet().size == levels.size) {
+            "Duplicate name for Career level"
+        }
     }
 
     override fun replace(original: Career): Career {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Career.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Career.kt
@@ -33,6 +33,19 @@ data class Career(
         require(races.isNotEmpty())
     }
 
+    override fun replace(original: Career): Career {
+        val originalLevelsByName = original.levels.associateBy { it.name }
+
+        return copy(
+            id = original.id,
+            levels = levels.map {
+                val originalLevel = originalLevelsByName[it.name]
+
+                if (originalLevel != null) it.copy(id = originalLevel.id) else it
+            }
+        )
+    }
+
     override fun duplicate(): Career = copy(name = duplicateName())
 
     @Parcelize

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Career.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Career.kt
@@ -76,5 +76,9 @@ data class Career(
     data class Skill(
         val expression: String,
         val isIncomeSkill: Boolean,
-    ) : Parcelable
+    ) : Parcelable {
+        init {
+            require(expression.isNotBlank())
+        }
+    }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Miracle.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Miracle.kt
@@ -39,5 +39,7 @@ data class Miracle(
         cultName.requireMaxLength(CULT_NAME_MAX_LENGTH, "cultName")
     }
 
+    override fun replace(original: Miracle) = copy(id = original.id)
+
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Skill.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Skill.kt
@@ -31,5 +31,7 @@ data class Skill(
         description.requireMaxLength(DESCRIPTION_MAX_LENGTH, "description")
     }
 
+    override fun replace(original: Skill) = copy(id = original.id)
+
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Spell.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Spell.kt
@@ -41,5 +41,7 @@ data class Spell(
         require(lore.length <= LORE_MAX_LENGTH) { "LORE must be shorter than $LORE_MAX_LENGTH" }
     }
 
+    override fun replace(original: Spell) = copy(id = original.id)
+
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Talent.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Talent.kt
@@ -30,5 +30,7 @@ data class Talent(
         require(maxTimesTaken.length <= MAX_TIMES_TAKEN_MAX_LENGTH) { "Maximum length of is $MAX_TIMES_TAKEN_MAX_LENGTH" }
     }
 
+    override fun replace(original: Talent) = copy(id = original.id)
+
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Trait.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Trait.kt
@@ -18,11 +18,8 @@ data class Trait(
     val description: String,
 ) : CompendiumItem<Trait>() {
     init {
-        if (description.length > DESCRIPTION_MAX_LENGTH) {
-            println(description)
-        }
         require(specifications.all { name.contains(it) })
-        require(name.isNotEmpty())
+        require(name.isNotBlank())
         require(name.length <= NAME_MAX_LENGTH) { "Maximum allowed name length is $NAME_MAX_LENGTH" }
         require(description.length <= DESCRIPTION_MAX_LENGTH) { "Maximum allowed description length is $DESCRIPTION_MAX_LENGTH" }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Trait.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Trait.kt
@@ -27,6 +27,8 @@ data class Trait(
         require(description.length <= DESCRIPTION_MAX_LENGTH) { "Maximum allowed description length is $DESCRIPTION_MAX_LENGTH" }
     }
 
+    override fun replace(original: Trait) = copy(id = original.id)
+
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
 
     companion object {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/JsonCompendiumImporter.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/JsonCompendiumImporter.kt
@@ -1,0 +1,61 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package cz.frantisekmasa.wfrp_master.common.compendium.domain.importer
+
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Blessing
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Career
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Miracle
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Skill
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Spell
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Talent
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Trait
+import cz.frantisekmasa.wfrp_master.common.compendium.import.CompendiumBundle
+import cz.frantisekmasa.wfrp_master.common.core.domain.ExceptionWithUserMessage
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import java.io.InputStream
+
+class JsonCompendiumImporter(stream: InputStream) : CompendiumImporter {
+    private val data: Result<CompendiumBundle> = runCatching {
+        try {
+            json.decodeFromStream(stream)
+        } catch (e: IllegalArgumentException) {
+            throw ExceptionWithUserMessage(e.message ?: "Unknown error", e)
+        }
+    }
+
+    override suspend fun importSkills(): List<Skill> {
+        return data.getOrThrow().skills.map { it.toSkill() }
+    }
+
+    override suspend fun importTalents(): List<Talent> {
+        return data.getOrThrow().talents.map { it.toTalent() }
+    }
+
+    override suspend fun importSpells(): List<Spell> {
+        return data.getOrThrow().spells.map { it.toSpell() }
+    }
+
+    override suspend fun importBlessings(): List<Blessing> {
+        return data.getOrThrow().blessings.map { it.toBlessing() }
+    }
+
+    override suspend fun importMiracles(): List<Miracle> {
+        return data.getOrThrow().miracles.map { it.toMiracle() }
+    }
+
+    override suspend fun importTraits(): List<Trait> {
+        return data.getOrThrow().traits.map { it.toTrait() }
+    }
+
+    override suspend fun importCareers(): List<Career> {
+        return data.getOrThrow().careers.map { it.toCareer() }
+    }
+
+    companion object {
+        private val json = Json {
+            ignoreUnknownKeys = true
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/BlessingImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/BlessingImport.kt
@@ -1,0 +1,45 @@
+package cz.frantisekmasa.wfrp_master.common.compendium.import
+
+import androidx.compose.runtime.Immutable
+import com.benasher44.uuid.uuid4
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Blessing
+import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Immutable
+data class BlessingImport(
+    val name: String,
+    val range: String,
+    val target: String,
+    val duration: String,
+    val effect: String,
+) {
+    init {
+        require(name.isNotBlank()) { "Blessing name cannot be blank" }
+        name.requireMaxLength(Blessing.NAME_MAX_LENGTH, "blessing name")
+        range.requireMaxLength(Blessing.RANGE_MAX_LENGTH, "blessing range")
+        target.requireMaxLength(Blessing.TARGET_MAX_LENGTH, "blessing target")
+        duration.requireMaxLength(Blessing.DURATION_MAX_LENGTH, "blessing duration")
+        effect.requireMaxLength(Blessing.EFFECT_MAX_LENGTH, "blessing effect")
+    }
+
+    fun toBlessing() = Blessing(
+        id = uuid4(),
+        name = name,
+        range = range,
+        target = target,
+        duration = duration,
+        effect = effect,
+    )
+
+    companion object {
+        fun fromBlessing(blessing: Blessing) = BlessingImport(
+            name = blessing.name,
+            range = blessing.range,
+            target = blessing.target,
+            duration = blessing.duration,
+            effect = blessing.effect,
+        )
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/CareerImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/CareerImport.kt
@@ -1,0 +1,101 @@
+package cz.frantisekmasa.wfrp_master.common.compendium.import
+
+import androidx.compose.runtime.Immutable
+import com.benasher44.uuid.uuid4
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Career
+import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
+import cz.frantisekmasa.wfrp_master.common.core.domain.Characteristic
+import cz.frantisekmasa.wfrp_master.common.core.domain.SocialClass
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.Race
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.SocialStatus
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Immutable
+data class CareerImport(
+    val name: String,
+    val description: String,
+    val socialClass: SocialClass,
+    val races: Set<Race>,
+    val levels: List<Level>,
+) {
+    init {
+        require(name.isNotBlank()) { "Career name cannot be blank" }
+        name.requireMaxLength(Career.NAME_MAX_LENGTH, "career name")
+        description.requireMaxLength(Career.DESCRIPTION_MAX_LENGTH, "career description")
+        require(races.isNotEmpty()) { "At least one race required for career \"$name\"" }
+        require(levels.map { it.name }.toSet().size == levels.size) {
+            "Duplicate name for career level of career \"$name\""
+        }
+    }
+
+    fun toCareer() = Career(
+        id = uuid4(),
+        name = name,
+        description = description,
+        socialClass = socialClass,
+        races = races,
+        levels = levels.map {
+            Career.Level(
+                id = uuid4(),
+                name = it.name,
+                status = it.status,
+                characteristics = it.characteristics,
+                skills = it.skills.map { skill ->
+                    Career.Skill(
+                        skill.expression,
+                        skill.isIncomeSkill
+                    )
+                },
+                talents = it.talents,
+                trappings = it.trappings,
+            )
+        }
+    )
+
+    @Serializable
+    @Immutable
+    data class Level(
+        val name: String,
+        val status: SocialStatus,
+        val characteristics: Set<Characteristic>,
+        val skills: List<Skill>,
+        val talents: List<String>,
+        val trappings: List<String>,
+    )
+
+    @Serializable
+    @Immutable
+    data class Skill(
+        val expression: String,
+        val isIncomeSkill: Boolean,
+    ) {
+        init {
+            require(expression.isNotBlank()) { "Career skill expression cannot be blank" }
+        }
+    }
+
+    companion object {
+        fun fromCareer(career: Career) = CareerImport(
+            name = career.name,
+            description = career.description,
+            socialClass = career.socialClass,
+            races = career.races,
+            levels = career.levels.map {
+                Level(
+                    name = it.name,
+                    status = it.status,
+                    characteristics = it.characteristics,
+                    skills = it.skills.map { skill ->
+                        Skill(
+                            skill.expression,
+                            skill.isIncomeSkill
+                        )
+                    },
+                    talents = it.talents,
+                    trappings = it.trappings,
+                )
+            }
+        )
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/CompendiumBundle.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/CompendiumBundle.kt
@@ -1,0 +1,16 @@
+package cz.frantisekmasa.wfrp_master.common.compendium.import
+
+import androidx.compose.runtime.Immutable
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Immutable
+data class CompendiumBundle(
+    val skills: List<SkillImport> = emptyList(),
+    val talents: List<TalentImport> = emptyList(),
+    val spells: List<SpellImport> = emptyList(),
+    val miracles: List<MiracleImport> = emptyList(),
+    val blessings: List<BlessingImport> = emptyList(),
+    val traits: List<TraitImport> = emptyList(),
+    val careers: List<CareerImport> = emptyList(),
+)

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/MiracleImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/MiracleImport.kt
@@ -1,0 +1,49 @@
+package cz.frantisekmasa.wfrp_master.common.compendium.import
+
+import androidx.compose.runtime.Immutable
+import com.benasher44.uuid.uuid4
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Miracle
+import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Immutable
+data class MiracleImport(
+    val name: String,
+    val range: String,
+    val target: String,
+    val duration: String,
+    val effect: String,
+    val cultName: String,
+) {
+    init {
+        require(name.isNotBlank()) { "Miracle name cannot be blank" }
+        name.requireMaxLength(Miracle.NAME_MAX_LENGTH, "miracle name")
+        range.requireMaxLength(Miracle.RANGE_MAX_LENGTH, "miracle range")
+        target.requireMaxLength(Miracle.TARGET_MAX_LENGTH, "miracle target")
+        duration.requireMaxLength(Miracle.DURATION_MAX_LENGTH, "miracle duration")
+        effect.requireMaxLength(Miracle.EFFECT_MAX_LENGTH, "miracle effect")
+        cultName.requireMaxLength(Miracle.CULT_NAME_MAX_LENGTH, "miracle cultName")
+    }
+
+    fun toMiracle() = Miracle(
+        id = uuid4(),
+        name = name,
+        range = range,
+        target = target,
+        duration = duration,
+        effect = effect,
+        cultName = cultName,
+    )
+
+    companion object {
+        fun fromMiracle(miracle: Miracle) = MiracleImport(
+            name = miracle.name,
+            range = miracle.range,
+            target = miracle.target,
+            duration = miracle.duration,
+            effect = miracle.effect,
+            cultName = miracle.cultName,
+        )
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/SkillImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/SkillImport.kt
@@ -1,0 +1,40 @@
+package cz.frantisekmasa.wfrp_master.common.compendium.import
+
+import androidx.compose.runtime.Immutable
+import com.benasher44.uuid.uuid4
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Skill
+import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
+import cz.frantisekmasa.wfrp_master.common.core.domain.Characteristic
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Immutable
+data class SkillImport(
+    val name: String,
+    val description: String,
+    val characteristic: Characteristic,
+    val advanced: Boolean,
+) {
+    init {
+        require(name.isNotBlank()) { "Skill name cannot be blank" }
+        name.requireMaxLength(Skill.NAME_MAX_LENGTH, "skill name")
+        description.requireMaxLength(Skill.DESCRIPTION_MAX_LENGTH, "talent description")
+    }
+
+    fun toSkill() = Skill(
+        id = uuid4(),
+        name = name,
+        description = description,
+        characteristic = characteristic,
+        advanced = advanced,
+    )
+
+    companion object {
+        fun fromSkill(skill: Skill) = SkillImport(
+            name = skill.name,
+            description = skill.description,
+            characteristic = skill.characteristic,
+            advanced = skill.advanced,
+        )
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/SpellImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/SpellImport.kt
@@ -1,0 +1,53 @@
+package cz.frantisekmasa.wfrp_master.common.compendium.import
+
+import androidx.compose.runtime.Immutable
+import com.benasher44.uuid.uuid4
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Spell
+import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Immutable
+data class SpellImport(
+    val name: String,
+    val range: String,
+    val target: String,
+    val duration: String,
+    val castingNumber: Int,
+    val effect: String,
+    val lore: String,
+) {
+    init {
+        require(name.isNotBlank()) { "Spell name cannot be blank" }
+        name.requireMaxLength(Spell.NAME_MAX_LENGTH, "spell name")
+        require(castingNumber >= 0) { "Casting number cannot be negative for spell \"$name\"" }
+        range.requireMaxLength(Spell.RANGE_MAX_LENGTH, "spell range")
+        target.requireMaxLength(Spell.TARGET_MAX_LENGTH, "spell target")
+        duration.requireMaxLength(Spell.DURATION_MAX_LENGTH, "spell duration")
+        effect.requireMaxLength(Spell.EFFECT_MAX_LENGTH, "spell effect")
+        lore.requireMaxLength(Spell.LORE_MAX_LENGTH, "spell lore")
+    }
+
+    fun toSpell() = Spell(
+        id = uuid4(),
+        name = name,
+        range = range,
+        target = target,
+        duration = duration,
+        castingNumber = castingNumber,
+        effect = effect,
+        lore = lore,
+    )
+
+    companion object {
+        fun fromSpell(spell: Spell) = SpellImport(
+            name = spell.name,
+            range = spell.range,
+            target = spell.target,
+            duration = spell.duration,
+            castingNumber = spell.castingNumber,
+            effect = spell.effect,
+            lore = spell.lore,
+        )
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/TalentImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/TalentImport.kt
@@ -1,0 +1,36 @@
+package cz.frantisekmasa.wfrp_master.common.compendium.import
+
+import androidx.compose.runtime.Immutable
+import com.benasher44.uuid.uuid4
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Talent
+import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Immutable
+data class TalentImport(
+    val name: String,
+    val maxTimesTaken: String,
+    val description: String,
+) {
+    init {
+        require(name.isNotBlank()) { "Talent name cannot be blank" }
+        name.requireMaxLength(Talent.NAME_MAX_LENGTH, "talent name")
+        description.requireMaxLength(Talent.DESCRIPTION_MAX_LENGTH, "talent description")
+    }
+
+    fun toTalent() = Talent(
+        id = uuid4(),
+        name = name,
+        maxTimesTaken = maxTimesTaken,
+        description = description,
+    )
+
+    companion object {
+        fun fromTalent(talent: Talent) = TalentImport(
+            name = talent.name,
+            maxTimesTaken = talent.maxTimesTaken,
+            description = talent.description,
+        )
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/TraitImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/TraitImport.kt
@@ -1,0 +1,42 @@
+package cz.frantisekmasa.wfrp_master.common.compendium.import
+
+import androidx.compose.runtime.Immutable
+import com.benasher44.uuid.uuid4
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Trait
+import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Immutable
+data class TraitImport(
+    val name: String,
+    val specifications: Set<String>,
+    val description: String,
+) {
+    init {
+        require(name.isNotBlank()) { "Trait name cannot be blank" }
+        name.requireMaxLength(Trait.NAME_MAX_LENGTH, "trait name")
+        specifications.forEach {
+            require(it in name) {
+                "Trait name \"$name\" does not contain placeholder for specification \"$it\""
+            }
+        }
+        require(specifications.all { name.contains(it) })
+        description.requireMaxLength(Trait.DESCRIPTION_MAX_LENGTH, "trait description")
+    }
+
+    fun toTrait() = Trait(
+        id = uuid4(),
+        name = name,
+        specifications = specifications,
+        description = description,
+    )
+
+    companion object {
+        fun fromTrait(trait: Trait) = TraitImport(
+            name = trait.name,
+            specifications = trait.specifications,
+            description = trait.description,
+        )
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/common/functions.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/common/functions.kt
@@ -2,5 +2,5 @@ package cz.frantisekmasa.wfrp_master.common.core.common
 
 fun String.requireMaxLength(maxLength: Int, valueName: String) =
     require(length <= maxLength) {
-        "Maximum allowed length of \"$valueName\" is $maxLength, \"$this\" given"
+        "Maximum allowed length of \"$valueName\" is $maxLength characters, \"$this\" given"
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/ExceptionWithUserMessage.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/ExceptionWithUserMessage.kt
@@ -1,0 +1,6 @@
+package cz.frantisekmasa.wfrp_master.common.core.domain
+
+class ExceptionWithUserMessage(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/compendium/CompendiumItem.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/compendium/CompendiumItem.kt
@@ -10,5 +10,7 @@ abstract class CompendiumItem<T : CompendiumItem<T>> : Parcelable {
 
     abstract fun duplicate(): T
 
+    abstract fun replace(original: T): T
+
     protected fun duplicateName(): String = duplicateName(name)
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/shared/FileChooser.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/shared/FileChooser.kt
@@ -6,20 +6,37 @@ import java.io.InputStream
 
 @Composable
 expect fun rememberFileChooser(
-    onFileChoose: suspend CoroutineScope.(Result<File>) -> Unit
+    onFileChoose: suspend CoroutineScope.(Result<ReadableFile>) -> Unit
 ): FileChooser
 
-expect class File {
+@Composable
+expect fun rememberFileSaver(
+    type: FileType,
+    defaultFileName: String,
+    onLocationChoose: suspend CoroutineScope.(Result<WriteableFile>) -> Unit,
+): FileSaver
+
+expect class ReadableFile {
     val stream: InputStream
 
     fun readBytes(): ByteArray
+}
+
+expect class WriteableFile {
+    fun writeBytes(bytes: ByteArray)
+    fun close()
 }
 
 interface FileChooser {
     fun open(type: FileType)
 }
 
+fun interface FileSaver {
+    fun selectLocation()
+}
+
 enum class FileType {
     IMAGE,
-    PDF
+    PDF,
+    JSON
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -500,6 +500,7 @@ data class CompendiumMessageStrings(
     val itemAlreadyExists: String = "Item already exists",
     val noItems: String = "No items in compendium",
     val noItemsInCompendiumSubtextPlayer: String = "Your GM has to add them first.",
+    val willReplaceExistingItem: String = "Will replace existing item",
 )
 
 @Immutable

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -274,6 +274,7 @@ data class CareerMessageStrings(
     val notFound: String = "Career not found",
     val noLevel: String = "No career levels",
     val noLevelSubtext: String = "Create at least one level\nto let Characters use this career.",
+    val levelWithNameExists: String = "Career level with same name already exists",
 )
 
 @Immutable

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -465,13 +465,25 @@ data class CompendiumStrings(
     val searchPlaceholder: String = "Search items",
     val buttonBuy: String = "Buy",
     val buttonImport: String = "Import",
+    val buttonImportFromRulebook: String = "Import from Rulebook",
+    val buttonImportFile: String = "Import file",
     val buttonImportRulebook: String = "Import rulebook PDF",
+    val buttonExport: String = "Save Export",
+    val buttonExportFile: String = "Export file",
     val iconAddCompendiumItem: String = "Add compendium item",
-    val importPrompt: AnnotatedString = buildAnnotatedString {
+    val rulebookImportPrompt: AnnotatedString = buildAnnotatedString {
         append("Import compendium from official WFRP Rulebook PDF.")
         withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
             append("Only the latest version of English Rulebook is supported.")
         }
+    },
+    val jsonImportPrompt: AnnotatedString = buildAnnotatedString {
+        append("Import compendium previously exported from WFRP Master.\n")
+        withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
+            append("The export format is not set in stone yet!\n")
+        }
+        append("so while exports from the same version of WFRP Master will work,")
+        append("exports from previous versions may not work properly.")
     },
     val messages: CompendiumMessageStrings = CompendiumMessageStrings(),
     val pickPromptCareers: String = "Select which careers you want to import.",
@@ -491,13 +503,16 @@ data class CompendiumStrings(
     val tabTraits: String = "Traits",
     val title: String = "Compendium",
     val titleImportCompendium: String = "Import Compendium",
+    val titleExportCompendium: String = "Export Compendium",
     val titleImportDialog: String = "Importing Rulebook…",
 )
 
 @Immutable
 data class CompendiumMessageStrings(
+    val exportFailed: String = "JSON export failed.",
     val outOfMemory: String = "PDF import failed. Not enough available RAM on device.",
-    val importFailed: String = "PDF import failed. Check that you provided valid rulebook PDF.",
+    val rulebookImportFailed: String = "PDF import failed. Check that you provided valid rulebook PDF.",
+    val jsonImportFailed: String = "JSON import failed. Check that you provided valid WFRP Master export.",
     val itemAlreadyExists: String = "Item already exists",
     val noItems: String = "No items in compendium",
     val noItemsInCompendiumSubtextPlayer: String = "Your GM has to add them first.",

--- a/common/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/common/auth/AuthenticationManager.kt
+++ b/common/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/common/auth/AuthenticationManager.kt
@@ -60,7 +60,7 @@ class AuthenticationManager(
         @SerialName("refresh_token")
         val refreshToken: String,
         @SerialName("grant_type")
-        val grantType: String = "refresh_token",
+        val grantType: String,
     )
 
     @Serializable

--- a/common/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/shared/FileChooser.kt
+++ b/common/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/shared/FileChooser.kt
@@ -3,11 +3,17 @@ package cz.frantisekmasa.wfrp_master.common.core.shared
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.staticCompositionLocalOf
 import kotlinx.coroutines.CoroutineScope
+import java.io.File
 import java.io.InputStream
 
-typealias FileChooseListener = suspend CoroutineScope.(Result<File>) -> Unit
+typealias FileChooseListener = suspend CoroutineScope.(Result<ReadableFile>) -> Unit
+typealias FileLocationListener = suspend CoroutineScope.(Result<WriteableFile>) -> Unit
 
 val LocalFileChooserFactory = staticCompositionLocalOf<(FileChooseListener) -> FileChooser> {
+    error("LocalFileChooser was not set")
+}
+
+val LocalFileSaverFactory = staticCompositionLocalOf<(FileLocationListener) -> FileSaver> {
     error("LocalFileChooser was not set")
 }
 
@@ -16,8 +22,28 @@ actual fun rememberFileChooser(onFileChoose: FileChooseListener): FileChooser {
     return LocalFileChooserFactory.current(onFileChoose)
 }
 
-actual class File(
+@Composable
+actual fun rememberFileSaver(
+    type: FileType,
+    defaultFileName: String,
+    onLocationChoose: FileLocationListener,
+): FileSaver {
+    return LocalFileSaverFactory.current(onLocationChoose)
+}
+
+actual class ReadableFile(
     actual val stream: InputStream
 ) {
     actual fun readBytes(): ByteArray = stream.readBytes()
+}
+
+actual class WriteableFile(
+    private val file: File,
+) {
+    actual fun writeBytes(bytes: ByteArray) {
+        file.writeBytes(bytes)
+    }
+
+    actual fun close() {
+    }
 }

--- a/desktop/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/desktop/Main.kt
+++ b/desktop/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/desktop/Main.kt
@@ -15,6 +15,7 @@ import cz.frantisekmasa.wfrp_master.common.core.config.Platform
 import cz.frantisekmasa.wfrp_master.common.core.config.StaticConfiguration
 import cz.frantisekmasa.wfrp_master.common.core.shared.LocalEmailInitiator
 import cz.frantisekmasa.wfrp_master.common.core.shared.LocalFileChooserFactory
+import cz.frantisekmasa.wfrp_master.common.core.shared.LocalFileSaverFactory
 import cz.frantisekmasa.wfrp_master.common.core.shared.LocalUrlOpener
 import cz.frantisekmasa.wfrp_master.common.core.ui.responsive.ScreenWithBreakpoints
 import cz.frantisekmasa.wfrp_master.common.core.ui.theme.Theme
@@ -23,6 +24,7 @@ import cz.frantisekmasa.wfrp_master.common.shell.DrawerShell
 import cz.frantisekmasa.wfrp_master.desktop.interop.DesktopEmailInitiator
 import cz.frantisekmasa.wfrp_master.desktop.interop.DesktopUrlOpener
 import cz.frantisekmasa.wfrp_master.desktop.interop.NativeFileChooser
+import cz.frantisekmasa.wfrp_master.desktop.interop.NativeFileSaver
 import kotlinx.coroutines.launch
 import org.kodein.di.compose.withDI
 
@@ -36,6 +38,7 @@ fun main() {
                 LocalUrlOpener provides DesktopUrlOpener,
                 LocalEmailInitiator provides DesktopEmailInitiator,
                 LocalFileChooserFactory provides { NativeFileChooser(coroutineScope, it) },
+                LocalFileSaverFactory provides { NativeFileSaver(coroutineScope, it) },
                 LocalStaticConfiguration provides StaticConfiguration(
                     isProduction = true,
                     version = "dev",

--- a/desktop/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/desktop/interop/NativeFileChooser.kt
+++ b/desktop/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/desktop/interop/NativeFileChooser.kt
@@ -1,9 +1,9 @@
 package cz.frantisekmasa.wfrp_master.desktop.interop
 
-import cz.frantisekmasa.wfrp_master.common.core.shared.File
 import cz.frantisekmasa.wfrp_master.common.core.shared.FileChooseListener
 import cz.frantisekmasa.wfrp_master.common.core.shared.FileChooser
 import cz.frantisekmasa.wfrp_master.common.core.shared.FileType
+import cz.frantisekmasa.wfrp_master.common.core.shared.ReadableFile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.awt.FileDialog
@@ -27,7 +27,7 @@ class NativeFileChooser(
             onFileChoose(
                 when (file) {
                     null -> Result.failure(Exception("File not selected"))
-                    else -> Result.success(File(file.inputStream()))
+                    else -> Result.success(ReadableFile(file.inputStream()))
                 }
             )
         }
@@ -36,5 +36,6 @@ class NativeFileChooser(
     private fun allowedExtensions(fileType: FileType): List<String> = when (fileType) {
         FileType.PDF -> listOf(".pdf")
         FileType.IMAGE -> listOf(".jpg", ".jpeg", ".png", ".gif")
+        FileType.JSON -> listOf(".json")
     }
 }

--- a/desktop/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/desktop/interop/NativeFileSaver.kt
+++ b/desktop/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/desktop/interop/NativeFileSaver.kt
@@ -1,0 +1,37 @@
+package cz.frantisekmasa.wfrp_master.desktop.interop
+
+import cz.frantisekmasa.wfrp_master.common.core.shared.FileLocationListener
+import cz.frantisekmasa.wfrp_master.common.core.shared.FileSaver
+import cz.frantisekmasa.wfrp_master.common.core.shared.WriteableFile
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.awt.FileDialog
+import java.io.File
+import javax.swing.JFrame
+
+class NativeFileSaver(
+    private val coroutineScope: CoroutineScope,
+    private val onFileChoose: FileLocationListener,
+) : FileSaver {
+    override fun selectLocation() {
+        val dialog = FileDialog(JFrame("Save file"), "Save file", FileDialog.SAVE).apply {
+            isVisible = true
+        }
+
+        val directory = dialog.directory
+        val fileName = dialog.file
+
+        val file = if (directory.isNullOrBlank() || fileName.isNullOrBlank())
+            null
+        else File("$directory/$fileName")
+
+        coroutineScope.launch {
+            onFileChoose(
+                when (file) {
+                    null -> Result.failure(Exception("File not selected"))
+                    else -> Result.success(WriteableFile(file))
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
- Adds a way to export the current Party Compendium. And re-import it to the same or different party.
- Exported file is human-readable JSON and I plan to make this documented way to import homebrew stuff to the app in the future
- This also changes how imports (both for Rulebook and JSON) are applied when an item with the same name already exists and the user chooses to import it again. In previous versions new item was created, now this item replaces the existing one.