### PR TITLE
Character removal

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CharacterScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CharacterScreenModel.kt
@@ -60,6 +60,13 @@ class CharacterScreenModel(
         }
     }
 
+    suspend fun archive() {
+        // TODO: Remove this character from combat (see [Combat::removeNpc()])
+        val character = characters.get(characterId)
+
+        characters.save(characterId.partyId, character.archive())
+    }
+
     suspend fun changeAvatar(image: ByteArray) {
         avatarChanger.changeAvatar(characterId, image)
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterEdit/CharacterEditScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterEdit/CharacterEditScreen.kt
@@ -4,12 +4,17 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ListItem
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.zIndex
@@ -23,13 +28,17 @@ import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.BackButton
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.HorizontalLine
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.ItemIcon
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
 import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.Subtitle
 import cz.frantisekmasa.wfrp_master.common.core.ui.settings.SettingsCard
 import cz.frantisekmasa.wfrp_master.common.core.ui.settings.SettingsTitle
+import cz.frantisekmasa.wfrp_master.common.gameMaster.GameMasterScreen
 import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
+import cz.frantisekmasa.wfrp_master.common.partyList.PartyListScreen
 
 data class CharacterEditScreen(
     private val characterId: CharacterId,
@@ -75,7 +84,7 @@ data class CharacterEditScreen(
         Scaffold(
             topBar = { TopBar(character.name) }
         ) {
-            Column {
+            Column(Modifier.verticalScroll(rememberScrollState())) {
                 EditableCharacterAvatar(
                     screenModel = screenModel,
                     character = character,
@@ -156,6 +165,33 @@ data class CharacterEditScreen(
                             )
                         },
                         modifier = Modifier.clickable { openSection(Section.VISIBLE_TABS) },
+                    )
+
+                    HorizontalLine()
+
+                    val snackbarHolder = LocalPersistentSnackbarHolder.current
+                    var removalDialogOpened by remember { mutableStateOf(false) }
+
+                    if (removalDialogOpened) {
+                        CharacterRemovalDialog(
+                            character = character,
+                            onDismissRequest = { removalDialogOpened = false },
+                            onConfirmation = {
+                                screenModel.archive()
+                                snackbarHolder.showSnackbar(
+                                    strings.character.messages.characterRemoved,
+                                )
+                                navigator.popUntil {
+                                    it is GameMasterScreen || it == PartyListScreen
+                                }
+                            },
+                        )
+                    }
+
+                    ListItem(
+                        text = { Text(strings.character.titleRemoval) },
+                        secondaryText = { Text(strings.character.secondaryTextRemoval) },
+                        modifier = Modifier.clickable { removalDialogOpened = true },
                     )
                 }
             }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterEdit/CharacterRemovalDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterEdit/CharacterRemovalDialog.kt
@@ -2,7 +2,12 @@ package cz.frantisekmasa.wfrp_master.common.characterEdit
 
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
 import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.AlertDialog
 import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.DialogProgress

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterEdit/CharacterRemovalDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterEdit/CharacterRemovalDialog.kt
@@ -1,0 +1,55 @@
+package cz.frantisekmasa.wfrp_master.common.characterEdit
+
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.*
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
+import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.AlertDialog
+import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.DialogProgress
+import cz.frantisekmasa.wfrp_master.common.core.utils.launchLogged
+import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
+import kotlinx.coroutines.Dispatchers
+
+@Composable
+fun CharacterRemovalDialog(
+    character: Character,
+    onDismissRequest: () -> Unit,
+    onConfirmation: suspend () -> Unit,
+) {
+    val coroutineScope = rememberCoroutineScope()
+    var processing by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        text = {
+            if (processing) {
+                DialogProgress()
+                return@AlertDialog
+            }
+
+            Text(LocalStrings.current.character.messages.removalDialogText(character.name))
+        },
+        confirmButton = {
+            TextButton(
+                enabled = !processing,
+                onClick = {
+                    processing = true
+                    coroutineScope.launchLogged(Dispatchers.IO) {
+                        onConfirmation()
+                        onDismissRequest()
+                    }
+                }
+            ) {
+                Text(LocalStrings.current.commonUi.buttonRemove)
+            }
+        },
+        dismissButton = {
+            TextButton(
+                enabled = !processing,
+                onClick = onDismissRequest
+            ) {
+                Text(LocalStrings.current.commonUi.buttonCancel)
+            }
+        }
+    )
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/Character.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/Character.kt
@@ -71,7 +71,6 @@ data class Character(
         require(motivation.length <= MOTIVATION_MAX_LENGTH) { "Motivation is too long" }
         require(mutation.length <= MUTATION_MAX_LENGTH) { "Mutation is too long" }
         require(note.length <= NOTE_MAX_LENGTH) { "Note is too long" }
-        require(!isArchived || userId == null) { "Only non-user-characters can be archived" }
 
         val maxWounds = calculateMaxWounds(
             size ?: race?.size,
@@ -225,7 +224,10 @@ data class Character(
 
     fun updateConditions(newConditions: CurrentConditions) = copy(conditions = newConditions)
 
-    fun archive() = copy(isArchived = true)
+    fun archive() = copy(
+        isArchived = true,
+        userId = null,
+    )
 
     companion object {
         const val NAME_MAX_LENGTH = 50

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/gameMaster/GameMasterScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/gameMaster/GameMasterScreenModel.kt
@@ -39,6 +39,7 @@ class GameMasterScreenModel(
         }
 
     suspend fun archiveCharacter(id: CharacterId) {
+        // TODO: Remove this character from combat (see [Combat::removeNpc()])
         val character = characterRepository.get(id)
 
         characterRepository.save(id.partyId, character.archive())

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/gameMaster/PartySummaryScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/gameMaster/PartySummaryScreen.kt
@@ -276,13 +276,11 @@ private fun PlayerItem(
                 name = character.name,
                 icon = { CharacterAvatar(character.avatarUrl, ItemIcon.Size.Small) },
                 onClick = { onCharacterOpenRequest(character) },
-                contextMenuItems = if (character.userId == null)
-                    listOf(
-                        ContextMenu.Item(strings.commonUi.buttonRemove) {
-                            onRemoveCharacter(character)
-                        }
-                    )
-                else emptyList()
+                contextMenuItems = listOf(
+                    ContextMenu.Item(strings.commonUi.buttonRemove) {
+                        onRemoveCharacter(character)
+                    }
+                )
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/gameMaster/PartySummaryScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/gameMaster/PartySummaryScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cz.frantisekmasa.wfrp_master.common.ambitions.AmbitionsCard
+import cz.frantisekmasa.wfrp_master.common.characterEdit.CharacterRemovalDialog
 import cz.frantisekmasa.wfrp_master.common.compendium.CompendiumScreen
 import cz.frantisekmasa.wfrp_master.common.compendium.CompendiumScreenModel
 import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
@@ -42,7 +42,6 @@ import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.Invitation
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
-import cz.frantisekmasa.wfrp_master.common.core.shared.IO
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
 import cz.frantisekmasa.wfrp_master.common.core.shared.drawableResource
 import cz.frantisekmasa.wfrp_master.common.core.ui.CharacterAvatar
@@ -59,9 +58,7 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenMode
 import cz.frantisekmasa.wfrp_master.common.invitation.InvitationDialog
 import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 import cz.frantisekmasa.wfrp_master.common.skillTest.SkillTestDialog
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.launch
 
 @Composable
 internal fun Screen.PartySummaryScreen(
@@ -112,18 +109,23 @@ internal fun Screen.PartySummaryScreen(
                 )
             }
 
-            val coroutineScope = rememberCoroutineScope()
+            val (removedCharacter, setRemovedCharacter) = remember { mutableStateOf<Character?>(null) }
+
+            if (removedCharacter != null) {
+                CharacterRemovalDialog(
+                    character = removedCharacter,
+                    onDismissRequest = { setRemovedCharacter(null) },
+                    onConfirmation = {
+                        screenModel.archiveCharacter(CharacterId(partyId, removedCharacter.id))
+                    },
+                )
+            }
 
             PlayersCard(
                 screenModel,
                 onCharacterOpenRequest = onCharacterOpenRequest,
                 onCharacterCreateRequest = onCharacterCreateRequest,
-                onRemoveCharacter = {
-                    // TODO: Remove this character from combat (see [Combat::removeNpc()])
-                    coroutineScope.launch(Dispatchers.IO) {
-                        screenModel.archiveCharacter(CharacterId(partyId, it.id))
-                    }
-                },
+                onRemoveCharacter = { setRemovedCharacter(it) },
                 onInvitationDialogRequest = { invitationDialogVisible = true },
             )
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -303,6 +303,7 @@ data class CharacterStrings(
     val secondaryTextExperience: String = "XP, Ambitions",
     val secondaryTextWellBeing: String = "Corruption, Injuries, Diseases, Psychology",
     val secondaryTextWounds: String = "Max Wounds, Hardy talent advances",
+    val secondaryTextRemoval: String = "Permanently remove the Character",
     val tabsVisible: (visible: Int, total: Int) -> String = { visible, total ->
         "$visible of $total tabs visible"
     },
@@ -320,6 +321,7 @@ data class CharacterStrings(
     val titleEdit: String = "Edit Character",
     val titleExperience: String = "Experience",
     val titleGeneralSettings: String = "General",
+    val titleRemoval: String = "Remove Character",
     val titleSelectCharacter: String = "Select Character",
     val titleUiSettings: String = "UI settings",
     val titleVisibleTabs: String = "Visible tabs",
@@ -344,6 +346,7 @@ data class CharacteristicStrings(
 
 @Immutable
 data class CharacterMessageStrings(
+    val characterRemoved: String = "Character has been removed.",
     val noEquippedWeapons: String = "No equipped weapons",
     val noEquippedWeaponsSubText: String = "Character does not have any Weapon trappings equipped",
     val removalDialogText: (characterName: String) -> AnnotatedString = { characterName ->

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -346,6 +346,13 @@ data class CharacteristicStrings(
 data class CharacterMessageStrings(
     val noEquippedWeapons: String = "No equipped weapons",
     val noEquippedWeaponsSubText: String = "Character does not have any Weapon trappings equipped",
+    val removalDialogText: (characterName: String) -> AnnotatedString = { characterName ->
+        buildAnnotatedString {
+            append("Do you really want to permanently remove ")
+            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(characterName) }
+            append("?")
+        }
+    }
 )
 
 @Immutable


### PR DESCRIPTION
Closes https://github.com/fmasa/wfrp-master/issues/40

This PR lets Players remove their Characters (via the new option in the Edit Character screen) and also drops a limitation that prevented GMs from removing such characters as well.
