### PR TITLE
Combat improvements and fixes

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/ActiveCombatScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/ActiveCombatScreen.kt
@@ -67,7 +67,6 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.forms.NumberPicker
 import cz.frantisekmasa.wfrp_master.common.core.ui.menu.DropdownMenu
 import cz.frantisekmasa.wfrp_master.common.core.ui.menu.DropdownMenuItem
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.DraggableListFor
-import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.ItemIcon
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
@@ -194,12 +193,14 @@ class ActiveCombatScreen(
                     val turn = viewModel.turn.collectWithLifecycle(null).value
 
                     if (combatants == null || round == null || turn == null || party == null) {
-                        FullScreenProgress()
                         Box(
                             modifier = Modifier.fillMaxSize(),
                             contentAlignment = Alignment.Center,
                         ) {
-                            Column {
+                            Column(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                            ) {
                                 CircularProgressIndicator()
                                 Text(LocalStrings.current.combat.messages.waitingForCombat)
                             }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/ActiveCombatScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/ActiveCombatScreen.kt
@@ -13,7 +13,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.BottomAppBar
 import androidx.compose.material.CircularProgressIndicator
@@ -46,6 +48,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
@@ -63,6 +66,7 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.StatBlockData
 import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.BackButton
 import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.DialogProgress
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
+import cz.frantisekmasa.wfrp_master.common.core.ui.forms.Colors
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.NumberPicker
 import cz.frantisekmasa.wfrp_master.common.core.ui.menu.DropdownMenu
 import cz.frantisekmasa.wfrp_master.common.core.ui.menu.DropdownMenuItem
@@ -72,6 +76,7 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
 import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.OptionsAction
 import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.Subtitle
+import cz.frantisekmasa.wfrp_master.common.core.ui.theme.Theme
 import cz.frantisekmasa.wfrp_master.common.encounters.CombatantItem
 import cz.frantisekmasa.wfrp_master.common.encounters.domain.Wounds
 import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
@@ -304,6 +309,7 @@ class ActiveCombatScreen(
             CombatantListItem(
                 onTurn = index == turn - 1,
                 combatant,
+                isGameMaster = isGameMaster,
                 isDragged = isDragged,
                 modifier = when {
                     canEditCombatant(userId, isGameMaster, combatant) -> Modifier.clickable {
@@ -441,6 +447,7 @@ class ActiveCombatScreen(
         onTurn: Boolean,
         combatant: CombatantItem,
         isDragged: Boolean,
+        isGameMaster: Boolean,
         modifier: Modifier
     ) {
         Surface(
@@ -471,7 +478,15 @@ class ActiveCombatScreen(
                             }
                         }
                     },
-                    text = { Text(combatant.name) },
+                    text = {
+                        Column {
+                            Text(combatant.name)
+
+                            if (isGameMaster) {
+                                WoundsBar(combatant.wounds.current, combatant.wounds.max)
+                            }
+                        }
+                    },
                     trailing = {
                         Column(horizontalAlignment = Alignment.End) {
                             Text("I: ${combatant.combatant.initiative}")
@@ -483,6 +498,38 @@ class ActiveCombatScreen(
                             }
                         }
                     }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WoundsBar(current: Int, max: Int) {
+    if (max == 0) {
+        return
+    }
+
+    Row {
+        Text("$current/$max", style= MaterialTheme.typography.caption)
+
+        Surface(
+            shape = RoundedCornerShape(2.dp),
+            modifier = Modifier
+                .padding(top = Spacing.small, start = Spacing.tiny)
+                .fillMaxWidth()
+        ) {
+            Box(
+                Modifier.fillMaxWidth()
+                    .background(Color(183, 28, 28))
+            ) {
+                Box(
+                    Modifier.fillMaxWidth(current.toFloat() / max)
+                        .background(
+                            if (MaterialTheme.colors.isLight)
+                                Color(76, 175, 80)
+                            else Color(129, 199, 132))
+                        .height(4.dp)
                 )
             }
         }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/ActiveCombatScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/ActiveCombatScreen.kt
@@ -24,21 +24,21 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.ListItem
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
-import androidx.compose.material.SwipeableDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.ArrowForward
-import androidx.compose.material.icons.rounded.OpenInNew
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -61,8 +61,10 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.CharacterAvatar
 import cz.frantisekmasa.wfrp_master.common.core.ui.StatBlock
 import cz.frantisekmasa.wfrp_master.common.core.ui.StatBlockData
 import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.BackButton
+import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.DialogProgress
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.NumberPicker
+import cz.frantisekmasa.wfrp_master.common.core.ui.menu.DropdownMenu
 import cz.frantisekmasa.wfrp_master.common.core.ui.menu.DropdownMenuItem
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.DraggableListFor
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
@@ -88,45 +90,70 @@ class ActiveCombatScreen(
         val viewModel: CombatScreenModel = rememberScreenModel(arg = partyId)
 
         val coroutineScope = rememberCoroutineScope()
+        val navigator = LocalNavigator.currentOrThrow
 
         val party = viewModel.party.collectWithLifecycle(null).value
         val combatants = remember { viewModel.combatants() }.collectWithLifecycle(null).value
         val isGameMaster = LocalUser.current.id == party?.gameMasterId
 
-        var openedCombatant by remember { mutableStateOf<CombatantItem?>(null) }
-        val bottomSheetState = rememberNotSavedModalBottomSheetState()
+        val (openedCombatant, setOpenedCombatant) = remember { mutableStateOf<CombatantItem?>(null) }
+        val freshCombatant = if (openedCombatant != null)
+            combatants?.firstOrNull { it.areSameEntity(openedCombatant) }
+        else null
+
+        val bottomSheetState = rememberModalBottomSheetState(
+            ModalBottomSheetValue.Hidden,
+            skipHalfExpanded = true,
+        )
 
         ModalBottomSheetLayout(
             sheetState = bottomSheetState,
             sheetShape = MaterialTheme.shapes.small,
             sheetContent = {
-                if (!bottomSheetState.isVisible) {
-                    Box(Modifier.height(1.dp))
+                Box(Modifier.height(1.dp))
+
+                if (openedCombatant == null) {
+                    DialogProgress()
                     return@ModalBottomSheetLayout
                 }
 
-                openedCombatant?.let { combatant ->
-                    if (party == null) {
-                        return@let
-                    }
+                if (party == null || freshCombatant == null) {
+                    return@ModalBottomSheetLayout
+                }
 
-                    /*
-                 There are two things happening
+                /*
+                 There are two things happening:
                  1. We always need fresh version of given combatant,
                     because user may have edited combatant, i.e. by changing her advantage.
                     So we cannot used value from saved mutable state.
                  2. We have to show sheet only if fresh combatant is in the collection,
                     because she may have been removed from combat.
                  */
-                    val freshCombatant =
-                        combatants?.firstOrNull { it.areSameEntity(combatant) } ?: return@let
 
-                    val advantageCap by derivedStateOf {
-                        party.settings.advantageCap.calculate(freshCombatant.characteristics)
-                    }
-
-                    CombatantSheet(freshCombatant, viewModel, advantageCap)
+                val advantageCap by derivedStateOf {
+                    party.settings.advantageCap.calculate(freshCombatant.characteristics)
                 }
+
+                val combatantId = freshCombatant.combatant.id
+                CombatantSheet(
+                    freshCombatant,
+                    viewModel,
+                    advantageCap,
+                    onRemoveRequest = combatantId?.let {
+                        {
+                            coroutineScope.launch {
+                                if (combatants?.size == 1) {
+                                    viewModel.endCombat()
+                                    navigator.pop()
+                                } else {
+                                    viewModel.removeCombatant(combatantId)
+                                    setOpenedCombatant(null)
+                                    bottomSheetState.hide()
+                                }
+                            }
+                        }
+                    }
+                )
             },
         ) {
             Column {
@@ -149,8 +176,6 @@ class ActiveCombatScreen(
                                 }
 
                                 OptionsAction {
-                                    val navigator = LocalNavigator.currentOrThrow
-
                                     DropdownMenuItem(
                                         content = { Text(strings.combat.buttonEndCombat) },
                                         onClick = {
@@ -188,17 +213,19 @@ class ActiveCombatScreen(
                                 .weight(1f)
                                 .verticalScroll(rememberScrollState())
                         ) {
-                            CombatantList(
-                                coroutineScope = coroutineScope,
-                                combatants = combatants,
-                                viewModel = viewModel,
-                                turn = turn,
-                                isGameMaster = isGameMaster,
-                                onCombatantClicked = {
-                                    openedCombatant = it
-                                    coroutineScope.launch { bottomSheetState.show() }
-                                }
-                            )
+                            key(combatants) {
+                                CombatantList(
+                                    coroutineScope = coroutineScope,
+                                    combatants = combatants,
+                                    viewModel = viewModel,
+                                    turn = turn,
+                                    isGameMaster = isGameMaster,
+                                    onCombatantClicked = {
+                                        setOpenedCombatant(it)
+                                        coroutineScope.launch { bottomSheetState.show() }
+                                    },
+                                )
+                            }
                         }
 
                         if (isGameMaster) {
@@ -253,17 +280,6 @@ class ActiveCombatScreen(
     }
 
     @Composable
-    private fun rememberNotSavedModalBottomSheetState(): ModalBottomSheetState {
-        return remember {
-            ModalBottomSheetState(
-                initialValue = ModalBottomSheetValue.Hidden,
-                animationSpec = SwipeableDefaults.AnimationSpec,
-                confirmStateChange = { true },
-            )
-        }
-    }
-
-    @Composable
     private fun CombatantList(
         coroutineScope: CoroutineScope,
         combatants: List<CombatantItem>,
@@ -303,6 +319,7 @@ class ActiveCombatScreen(
         combatant: CombatantItem,
         viewModel: CombatScreenModel,
         advantageCap: Advantage,
+        onRemoveRequest: (() -> Unit)?,
     ) {
         Column(
             Modifier
@@ -311,18 +328,14 @@ class ActiveCombatScreen(
             verticalArrangement = Arrangement.spacedBy(Spacing.small),
         ) {
             val navigator = LocalNavigator.currentOrThrow
-
             Row(
-                Modifier.align(Alignment.CenterHorizontally),
+                modifier = Modifier.align(Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
                     combatant.name,
                     style = MaterialTheme.typography.h6,
-                )
-
-                IconButton(
-                    onClick = {
+                    modifier = Modifier.clickable {
                         navigator.push(
                             when (combatant) {
                                 is CombatantItem.Npc -> NpcDetailScreen(combatant.npcId)
@@ -332,13 +345,27 @@ class ActiveCombatScreen(
                                 )
                             }
                         )
-                    },
-                ) {
-                    Icon(
-                        Icons.Rounded.OpenInNew,
-                        LocalStrings.current.commonUi.buttonDetail,
-                        tint = MaterialTheme.colors.primary
-                    )
+                    }
+                )
+
+                if (onRemoveRequest != null) {
+                    var contextMenuExpanded by remember { mutableStateOf(false) }
+                    Box {
+                        IconButton(onClick = { contextMenuExpanded = true }) {
+                            Icon(
+                                Icons.Filled.MoreVert,
+                                LocalStrings.current.commonUi.labelOpenContextMenu,
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = contextMenuExpanded,
+                            onDismissRequest = { contextMenuExpanded = false },
+                        ) {
+                            DropdownMenuItem(onClick = onRemoveRequest) {
+                                Text(LocalStrings.current.combat.buttonRemoveCombatant)
+                            }
+                        }
+                    }
                 }
             }
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/CombatScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/CombatScreenModel.kt
@@ -290,6 +290,7 @@ class CombatScreenModel(
         if (combatant.combatant.wounds != null) {
             // Wounds are combatant specific (there may be multiple combatants of same character)
             updateCombat { it.updateCombatant(combatant.combatant.withWounds(wounds)) }
+            return
         }
 
         when (combatant) {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/ConditionsDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/ConditionsDialog.kt
@@ -1,0 +1,51 @@
+package cz.frantisekmasa.wfrp_master.common.combat
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import cz.frantisekmasa.wfrp_master.common.character.conditions.ConditionsForm
+import cz.frantisekmasa.wfrp_master.common.core.shared.IO
+import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.CloseButton
+import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.FullScreenDialog
+import cz.frantisekmasa.wfrp_master.common.encounters.CombatantItem
+import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@Composable
+fun ConditionsDialog(
+    combatantItem: CombatantItem,
+    screenModel: CombatScreenModel,
+    onDismissRequest: () -> Unit,
+) {
+    FullScreenDialog(onDismissRequest = onDismissRequest) {
+        val conditions = combatantItem.conditions
+        val coroutineScope = rememberCoroutineScope()
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    navigationIcon = { CloseButton(onDismissRequest) },
+                    title = { Text(LocalStrings.current.character.tabConditions) },
+                )
+            }
+        ) {
+            ConditionsForm(
+                modifier = Modifier.fillMaxSize(),
+                conditions = conditions,
+                onUpdate = { newConditions ->
+                    coroutineScope.launch {
+                        withContext(Dispatchers.IO) {
+                            screenModel.updateConditions(combatantItem, newConditions)
+                        }
+                    }
+                }
+            )
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/StartCombatDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/StartCombatDialog.kt
@@ -172,7 +172,7 @@ private fun NpcCharacterList(items: MutableMap<Character, Int>) {
                     NumberPicker(
                         value = count,
                         onIncrement = { items[character] = count + 1 },
-                        onDecrement = { items[character] = (count + 1).coerceAtLeast(0) },
+                        onDecrement = { items[character] = (count - 1).coerceAtLeast(0) },
                     )
                 },
             )

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/CurrentConditions.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/CurrentConditions.kt
@@ -1,14 +1,23 @@
 package cz.frantisekmasa.wfrp_master.common.core.domain.character
 
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelable
+import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelize
 import kotlinx.serialization.Serializable
 
 @Serializable
 @Immutable
-class CurrentConditions private constructor(private val conditions: Map<Condition, Int>) {
+@Parcelize
+class CurrentConditions private constructor(
+    private val conditions: Map<Condition, Int>
+) : Parcelable {
     companion object {
         fun none() = CurrentConditions(emptyMap())
     }
+
+    @Stable
+    fun areEmpty(): Boolean = conditions.isEmpty()
 
     fun addConditions(vararg conditions: Condition) =
         conditions.fold(this) { acc, condition ->
@@ -29,7 +38,16 @@ class CurrentConditions private constructor(private val conditions: Map<Conditio
         }
     fun count(condition: Condition) = conditions.getOrElse(condition, { 0 })
 
+    @Stable
     fun toMap() = conditions
+
+    @Stable
+    fun toList(): List<Pair<Condition, Int>> {
+        return conditions.asSequence()
+            .sortedBy { it.key }
+            .map { it.toPair() }
+            .toList()
+    }
 
     private fun withCondition(condition: Condition, count: Int) = CurrentConditions(
         mapOf(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/combat/Combat.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/combat/Combat.kt
@@ -1,6 +1,7 @@
 package cz.frantisekmasa.wfrp_master.common.core.domain.party.combat
 
 import androidx.compose.runtime.Immutable
+import com.benasher44.uuid.Uuid
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.NpcId
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelable
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelize
@@ -67,8 +68,16 @@ data class Combat(
     private fun <T> List<T>.containsSameItems(other: List<T>) =
         other.size == size || other.containsAll(this)
 
+    fun removeCombatant(id: Uuid): Combat? {
+        return removeFirstCombatant { it.id == id }
+    }
+
     fun removeNpc(npcId: NpcId): Combat? {
-        val removedIndex = combatants.indexOfFirst { it is Combatant.Npc && it.npcId == npcId }
+        return removeFirstCombatant { it is Combatant.Npc && it.npcId == npcId }
+    }
+
+    private fun removeFirstCombatant(predicate: (Combatant) -> Boolean): Combat? {
+        val removedIndex = combatants.indexOfFirst(predicate)
 
         if (removedIndex == -1) {
             return this

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/combat/Combatant.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/combat/Combatant.kt
@@ -2,6 +2,7 @@ package cz.frantisekmasa.wfrp_master.common.core.domain.party.combat
 
 import androidx.compose.runtime.Immutable
 import com.benasher44.uuid.Uuid
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.CurrentConditions
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.NpcId
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelable
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelize
@@ -20,10 +21,12 @@ sealed class Combatant : Parcelable {
     abstract val initiative: Int
     abstract val name: String?
     abstract val wounds: Wounds?
+    abstract val conditions: CurrentConditions?
 
     abstract fun withAdvantage(advantage: Advantage): Combatant
     abstract fun withInitiative(initiative: Int): Combatant
     abstract fun withWounds(wounds: Wounds): Combatant
+    abstract fun withConditions(conditions: CurrentConditions): Combatant
 
     fun areSameEntity(other: Combatant): Boolean {
         if (id != null || other.id != null) {
@@ -45,10 +48,12 @@ sealed class Combatant : Parcelable {
         override val name: String? = null,
         override val wounds: Wounds? = null,
         override val advantage: Advantage = Advantage.ZERO,
+        override val conditions: CurrentConditions? = null,
     ) : Combatant() {
         override fun withAdvantage(advantage: Advantage): Character = copy(advantage = advantage)
         override fun withInitiative(initiative: Int): Character = copy(initiative = initiative)
         override fun withWounds(wounds: Wounds) = copy(wounds = wounds)
+        override fun withConditions(conditions: CurrentConditions) = copy(conditions = conditions)
     }
 
     @Parcelize
@@ -61,10 +66,12 @@ sealed class Combatant : Parcelable {
         override val initiative: Int,
         override val name: String? = null,
         override val wounds: Wounds? = null,
-        override val advantage: Advantage = Advantage.ZERO
+        override val advantage: Advantage = Advantage.ZERO,
+        override val conditions: CurrentConditions = CurrentConditions.none(),
     ) : Combatant() {
         override fun withAdvantage(advantage: Advantage): Npc = copy(advantage = advantage)
         override fun withInitiative(initiative: Int): Npc = copy(initiative = initiative)
         override fun withWounds(wounds: Wounds) = copy(wounds = wounds)
+        override fun withConditions(conditions: CurrentConditions) = copy(conditions = conditions)
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/StatBlock.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/StatBlock.kt
@@ -85,7 +85,7 @@ fun StatBlock(
     }
 
     CharacterItemList(
-        title = LocalStrings.current.skills.titleSkills,
+        title = LocalStrings.current.traits.titleTraits,
         items = data.traits,
         value = { it.evaluatedName },
         detail = { trait, onDismissRequest -> TraitDetail(trait, onDismissRequest) },
@@ -124,7 +124,7 @@ fun StatBlock(
     )
 
     CharacterItemList(
-        title = LocalStrings.current.blessings.title,
+        title = LocalStrings.current.miracles.title,
         items = data.miracles,
         value = { it.name },
         detail = { miracle, onDismissRequest -> MiracleDetail(miracle, onDismissRequest) },

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/CombatantItem.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/CombatantItem.kt
@@ -2,6 +2,7 @@ package cz.frantisekmasa.wfrp_master.common.encounters
 
 import androidx.compose.runtime.Immutable
 import cz.frantisekmasa.wfrp_master.common.core.domain.Stats
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.CurrentConditions
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.NpcId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.combat.Combatant
@@ -14,6 +15,7 @@ sealed class CombatantItem {
     abstract val name: String
     abstract val characteristics: Stats
     abstract val wounds: Wounds
+    abstract val conditions: CurrentConditions
 
     fun areSameEntity(other: CombatantItem): Boolean = combatant.areSameEntity(other.combatant)
 
@@ -39,6 +41,9 @@ sealed class CombatantItem {
         override val wounds
             get() = combatant.wounds ?: character.wounds
 
+        override val conditions: CurrentConditions
+            get() = combatant.conditions ?: character.conditions
+
         val note: String get() = character.note
     }
 
@@ -56,5 +61,8 @@ sealed class CombatantItem {
 
         override val wounds
             get() = combatant.wounds ?: npc.wounds
+
+        override val conditions: CurrentConditions
+            get() = combatant.conditions
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -439,6 +439,7 @@ data class CombatStrings(
     val advantageCap: String = "Advantage Cap",
     val advantageUnlimited: String = "Unlimited",
     val buttonEndCombat: String = "End combat",
+    val buttonRemoveCombatant: String = "Remove from combat",
     val iconNextTurn: String = "Next turn",
     val hitLocations: HitLocationStrings = HitLocationStrings(),
     val iconPreviousTurn: String = "Previous turn",

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -458,6 +458,7 @@ data class CombatStrings(
 @Immutable
 data class CombatMessageStrings(
     val combatInProgress: String = "Combat is in progress",
+    val noConditions: String = "No Conditions",
     val waitingForCombat: String = "Waiting for Combat…",
 )
 


### PR DESCRIPTION
- GM can remove combatants from current combat
- Combatants now track Conditions - so you may track conditions for individual combatants created from a single NPC. When only one instance of combatant is created from NPC, NPC's conditions are changed directly and the changes will persist even after combat (the same way the Wounds work now).
- GM can now see current and maximum Wounds for all combatants at a glance
- Everyone can see the current Combatants' Conditions at a glance

I also fixed several bugs that I encountered:

- Fixed `(-)` button in *Start Combat* screen increasing rather than decreasing number of combatants
- Fixed NPC's Wounds being changed when editing combatant-specific wounds
- Fixed wrong text labels for Traits and Miracles in combatants screen 