### PR TITLE
Add Tests as separate fields to Talent

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/TalentsScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/TalentsScreenModel.kt
@@ -40,6 +40,7 @@ class TalentsScreenModel(
                 id = talentId,
                 compendiumId = compendiumTalent.id,
                 name = compendiumTalent.name,
+                tests = compendiumTalent.tests,
                 description = compendiumTalent.description,
                 taken = timesTaken,
             )

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/dialog/NonCompendiumTalentForm.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/dialog/NonCompendiumTalentForm.kt
@@ -24,6 +24,7 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.forms.TextInput
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.inputValue
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
 import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Talent.Companion as CompendiumTalent
 
 @Composable
 internal fun NonCompendiumTalentForm(
@@ -64,6 +65,13 @@ internal fun NonCompendiumTalentForm(
         }
 
         TextInput(
+            label = strings.labelTests,
+            value = formData.tests,
+            validate = validate,
+            maxLength = CompendiumTalent.TESTS_MAX_LENGTH,
+        )
+
+        TextInput(
             label = strings.labelDescription,
             value = formData.description,
             validate = validate,
@@ -77,6 +85,7 @@ internal fun NonCompendiumTalentForm(
 private class NonCompendiumTalentFormData(
     val id: Uuid,
     val name: InputValue,
+    val tests: InputValue,
     val description: InputValue,
     val taken: MutableState<Int>,
 ) : HydratedFormData<Talent> {
@@ -85,6 +94,7 @@ private class NonCompendiumTalentFormData(
         fun fromTalent(talent: Talent?): NonCompendiumTalentFormData = NonCompendiumTalentFormData(
             id = remember { talent?.id ?: uuid4() },
             name = inputValue(talent?.name ?: "", Rules.NotBlank()),
+            tests = inputValue(talent?.tests ?: ""),
             description = inputValue(talent?.description ?: ""),
             taken = rememberSaveable { mutableStateOf(talent?.taken ?: 1) },
         )
@@ -94,7 +104,8 @@ private class NonCompendiumTalentFormData(
         id = id,
         compendiumId = null,
         name = name.value,
-        description = description.value,
+        tests = tests.value,
+        description = description.value.trim(),
         taken = taken.value,
     )
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/dialog/TalentDetail.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/dialog/TalentDetail.kt
@@ -36,6 +36,7 @@ fun TalentDetail(
 
             TalentDetailBody(
                 maxTimesTaken = null,
+                tests = talent.tests,
                 description = talent.description,
             )
         }
@@ -45,14 +46,16 @@ fun TalentDetail(
 @Composable
 fun TalentDetailBody(
     maxTimesTaken: String?,
+    tests: String,
     description: String,
 ) {
     Column(Modifier.padding(Spacing.bodyPadding)) {
         if (maxTimesTaken != null) {
-            SingleLineTextValue(
-                label = LocalStrings.current.talents.labelMaxTimesTaken,
-                value = maxTimesTaken,
-            )
+            SingleLineTextValue(LocalStrings.current.talents.labelMaxTimesTaken, maxTimesTaken)
+        }
+
+        if (tests.isNotBlank()) {
+            SingleLineTextValue(LocalStrings.current.talents.labelTests, tests)
         }
 
         RichText {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Talent.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Talent.kt
@@ -3,6 +3,7 @@ package cz.frantisekmasa.wfrp_master.common.compendium.domain
 import androidx.compose.runtime.Immutable
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
+import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.CompendiumItem
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelize
 import kotlinx.serialization.Contextual
@@ -14,6 +15,7 @@ import kotlinx.serialization.Serializable
 data class Talent(
     @Contextual override val id: Uuid,
     override val name: String,
+    val tests: String = "", // TODO: Remove default value in 3.0
     val maxTimesTaken: String,
     val description: String,
 ) : CompendiumItem<Talent>() {
@@ -21,11 +23,13 @@ data class Talent(
         const val NAME_MAX_LENGTH = 50
         const val MAX_TIMES_TAKEN_MAX_LENGTH = 100
         const val DESCRIPTION_MAX_LENGTH = 1500
+        const val TESTS_MAX_LENGTH = 200
     }
 
     init {
         require(name.isNotEmpty())
         require(name.length <= NAME_MAX_LENGTH) { "Maximum allowed name length is $NAME_MAX_LENGTH" }
+        tests.requireMaxLength(TESTS_MAX_LENGTH, "tests")
         require(description.length <= DESCRIPTION_MAX_LENGTH) { "Maximum allowed description length is $DESCRIPTION_MAX_LENGTH" }
         require(maxTimesTaken.length <= MAX_TIMES_TAKEN_MAX_LENGTH) { "Maximum length of is $MAX_TIMES_TAKEN_MAX_LENGTH" }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/TalentImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/TalentImport.kt
@@ -10,12 +10,14 @@ import kotlinx.serialization.Serializable
 @Immutable
 data class TalentImport(
     val name: String,
+    val associatedTests: String,
     val maxTimesTaken: String,
     val description: String,
 ) {
     init {
         require(name.isNotBlank()) { "Talent name cannot be blank" }
         name.requireMaxLength(Talent.NAME_MAX_LENGTH, "talent name")
+        associatedTests.requireMaxLength(Talent.TESTS_MAX_LENGTH, "associated tests")
         description.requireMaxLength(Talent.DESCRIPTION_MAX_LENGTH, "talent description")
     }
 
@@ -29,6 +31,7 @@ data class TalentImport(
     companion object {
         fun fromTalent(talent: Talent) = TalentImport(
             name = talent.name,
+            associatedTests = talent.tests,
             maxTimesTaken = talent.maxTimesTaken,
             description = talent.description,
         )

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentDetailScreen.kt
@@ -20,6 +20,7 @@ class TalentDetailScreen(
             detail = {
                 TalentDetailBody(
                     maxTimesTaken = it.maxTimesTaken,
+                    tests = it.tests,
                     description = it.description,
                 )
             }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentDialog.kt
@@ -48,6 +48,13 @@ fun TalentDialog(
             )
 
             TextInput(
+                label = strings.labelTests,
+                value = formData.tests,
+                validate = validate,
+                maxLength = Talent.TESTS_MAX_LENGTH,
+            )
+
+            TextInput(
                 label = strings.labelMaxTimesTaken,
                 value = formData.maxTimesTaken,
                 validate = validate,
@@ -69,6 +76,7 @@ fun TalentDialog(
 private data class TalentFormData(
     val id: Uuid,
     val name: InputValue,
+    val tests: InputValue,
     val maxTimesTaken: InputValue,
     val description: InputValue,
 ) : CompendiumItemFormData<Talent> {
@@ -77,6 +85,7 @@ private data class TalentFormData(
         fun fromTalent(talent: Talent?) = TalentFormData(
             id = remember { talent?.id ?: uuid4() },
             name = inputValue(talent?.name ?: "", Rules.NotBlank()),
+            tests = inputValue(talent?.tests ?: ""),
             maxTimesTaken = inputValue(talent?.maxTimesTaken ?: ""),
             description = inputValue(talent?.description ?: ""),
         )
@@ -85,6 +94,7 @@ private data class TalentFormData(
     override fun toValue() = Talent(
         id = id,
         name = name.value,
+        tests = tests.value.trim(),
         maxTimesTaken = maxTimesTaken.value,
         description = description.value,
     )

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/talents/Talent.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/talents/Talent.kt
@@ -2,10 +2,12 @@ package cz.frantisekmasa.wfrp_master.common.core.domain.talents
 
 import androidx.compose.runtime.Immutable
 import com.benasher44.uuid.Uuid
+import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterItem
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelize
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Talent.Companion as CompendiumTalent
 
 @Parcelize
 @Serializable
@@ -14,6 +16,7 @@ data class Talent(
     @Contextual override val id: Uuid,
     @Contextual override val compendiumId: Uuid? = null,
     val name: String,
+    val tests: String = "", // TODO: Remove default value in 3.0
     val description: String,
     val taken: Int
 ) : CharacterItem {
@@ -26,6 +29,7 @@ data class Talent(
         require(name.isNotEmpty())
         require(name.length <= NAME_MAX_LENGTH) { "Maximum allowed name length is $NAME_MAX_LENGTH" }
         require(description.length <= DESCRIPTION_MAX_LENGTH) { "Maximum allowed description length is $DESCRIPTION_MAX_LENGTH" }
+        tests.requireMaxLength(CompendiumTalent.TESTS_MAX_LENGTH, "tests")
         require(taken in 1..999) { "Skill can be taken 1-100x" }
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -949,6 +949,7 @@ data class NpcMessages(
 @Immutable
 data class TalentStrings(
     val buttonAddNonCompendium: String = "…or add non-Compendium talent",
+    val labelTests: String = "Tests",
     val labelDescription: String = "Description (Optional)",
     val labelName: String = "Name",
     val labelMaxTimesTaken: String = "Max",

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -39,11 +39,12 @@ service cloud.firestore {
                 allow delete: if isGameMaster();
 
                 function isValidTalent(talent) {
-                    return talent.keys().toSet() == ["id", "name", "maxTimesTaken", "description"].toSet()
+                    return ["id", "name", "maxTimesTaken", "description", "tests"].hasAll(talent.keys())
                         && talent.id is string && talent.id == talentId && isValidUuid(talent.id)
                         && talent.name is string && isNotBlank(talent.name) && talent.name.size() <= 50
                         && talent.maxTimesTaken is string && talent.name.size() <= 100
-                        && talent.description is string && talent.description.size() <= 1500;
+                        && talent.description is string && talent.description.size() <= 1500
+                        && (! ("tests" in talent) || (talent.tests is string && talent.tests.size() <= 200));
                 }
             }
 


### PR DESCRIPTION
Users can now track the Test line (see Talent Format on page 132 of Core Rulebook) as independent field.

This is the base for Tests UI in the future.