### PR TITLE
Completed Encounters

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/scaffolding/FilterBar.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/scaffolding/FilterBar.kt
@@ -1,0 +1,23 @@
+package cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
+
+@Composable
+fun FilterBar(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Surface(elevation = 2.dp) {
+        Box(
+            modifier = modifier.fillMaxWidth().padding(Spacing.tiny),
+            contentAlignment = Alignment.Center,
+        ) {
+            content()
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/EncountersScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/EncountersScreen.kt
@@ -1,35 +1,39 @@
 package cz.frantisekmasa.wfrp_master.common.encounters
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Card
+import androidx.compose.material.Divider
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
+import androidx.compose.material.ListItem
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Done
+import androidx.compose.material.icons.rounded.DragIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -37,15 +41,16 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.EncounterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
-import cz.frantisekmasa.wfrp_master.common.core.shared.drawableResource
 import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.HamburgerButton
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
+import cz.frantisekmasa.wfrp_master.common.core.ui.forms.CheckboxWithText
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.DraggableListFor
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.EmptyUI
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
-import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.ItemIcon
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.VisualOnlyIconDescription
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.FilterBar
 import cz.frantisekmasa.wfrp_master.common.encounters.domain.Encounter
 import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 
@@ -56,7 +61,14 @@ class EncountersScreen(
     @Composable
     override fun Content() {
         val screenModel: EncountersScreenModel = rememberScreenModel(arg = partyId)
-        val encounters = screenModel.encounters.collectWithLifecycle(null).value
+
+        var showCompleted by rememberSaveable { mutableStateOf(false) }
+
+        val encounters = (
+            if (showCompleted)
+                screenModel.allEncounters
+            else screenModel.notCompletedEncounters
+            ).collectWithLifecycle(null).value
 
         if (encounters == null) {
             FullScreenProgress()
@@ -89,11 +101,33 @@ class EncountersScreen(
 
             val navigator = LocalNavigator.currentOrThrow
 
-            EncounterList(
-                encounters,
-                screenModel,
-                onClick = { navigator.push(EncounterDetailScreen(EncounterId(partyId, it.id))) },
-            )
+            Column {
+                FilterBar {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        CheckboxWithText(
+                            checked = showCompleted,
+                            text = LocalStrings.current.encounters.buttonShowCompleted,
+                            onCheckedChange = { showCompleted = !showCompleted },
+                        )
+                    }
+                }
+
+                val onClick: (Encounter) -> Unit = {
+                    navigator.push(EncounterDetailScreen(EncounterId(partyId, it.id)))
+                }
+                if (showCompleted) {
+                    AllEncountersList(encounters, onClick)
+                } else {
+                    ActiveEncounterList(
+                        encounters,
+                        screenModel,
+                        onClick = onClick,
+                    )
+                }
+            }
         }
     }
 }
@@ -106,10 +140,63 @@ private fun AddEncounterButton(onCreateEncounterRequest: () -> Unit) {
 }
 
 @Composable
-private fun EncounterList(
+private fun AllEncountersList(encounters: List<Encounter>, onClick: (Encounter) -> Unit) {
+    LazyColumn {
+        items(encounters) { encounter ->
+            EncounterItem(
+                encounter,
+                onClick,
+                draggable = false,
+            )
+        }
+    }
+}
+
+@Composable
+fun EncounterItem(
+    encounter: Encounter,
+    onClick: (Encounter) -> Unit,
+    draggable: Boolean,
+) {
+    Column {
+        ListItem(
+            modifier = Modifier.clickable { onClick(encounter) },
+            icon = {
+                if (draggable) {
+                    Icon(
+                        Icons.Rounded.DragIndicator,
+                        VisualOnlyIconDescription,
+                        modifier = Modifier.height(
+                            with(ItemIcon.Size.Small) { dimensions + padding * 2 }
+                        )
+                    )
+                }
+            },
+            text = {
+                Text(encounter.name)
+            },
+            secondaryText = {
+                val npcCount = remember(encounter.characters) { encounter.characters.values.sum() }
+                Text("$npcCount ${LocalStrings.current.npcs.titlePlural}")
+            },
+            trailing = {
+                if (encounter.completed) {
+                    Icon(
+                        Icons.Rounded.Done,
+                        contentDescription = LocalStrings.current.encounters.labelCompleted,
+                    )
+                }
+            }
+        )
+        Divider()
+    }
+}
+
+@Composable
+private fun ActiveEncounterList(
     encounters: List<Encounter>,
     screenModel: EncountersScreenModel,
-    onClick: (Encounter) -> Unit
+    onClick: (Encounter) -> Unit,
 ) {
     if (encounters.isEmpty()) {
         val strings = LocalStrings.current.encounters
@@ -122,50 +209,32 @@ private fun EncounterList(
         return
     }
 
-    val icon = drawableResource(Resources.Drawable.Encounter)
-    val iconSize = 28.dp
-
     Column(
         Modifier
             .background(MaterialTheme.colors.background)
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(Spacing.bodyPaddingWithFab),
-        horizontalAlignment = Alignment.CenterHorizontally,
+            .verticalScroll(rememberScrollState()),
     ) {
         DraggableListFor(
             encounters,
             modifier = Modifier.fillMaxHeight(),
-            itemSpacing = Spacing.small,
             onReorder = {
                 screenModel.reorderEncounters(
                     it.mapIndexed { index, encounter -> encounter.id to index }.toMap()
                 )
             },
         ) { _, encounter, isDragged ->
-            Card(
-                elevation = if (isDragged) 6.dp else 2.dp,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onClick(encounter) }
+            Surface(
+                color = if (isDragged)
+                    MaterialTheme.colors.surface
+                else Color.Transparent,
+                elevation = if (isDragged) 1.dp else 0.dp,
             ) {
-                Row(
-                    Modifier.padding(12.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Image(
-                        icon,
-                        VisualOnlyIconDescription,
-                        Modifier.size(iconSize),
-                        colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface)
-                    )
-                    Text(
-                        encounter.name,
-                        modifier = Modifier.padding(start = 8.dp),
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.body1
-                    )
-                }
+                EncounterItem(
+                    encounter,
+                    onClick = onClick,
+                    draggable = true,
+                )
             }
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/EncountersScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/EncountersScreenModel.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.util.UUID
 
@@ -21,7 +23,15 @@ class EncountersScreenModel(
     private val encounterRepository: EncounterRepository
 ) : ScreenModel {
 
-    val encounters: Flow<List<Encounter>> by lazy { encounterRepository.findByParty(partyId) }
+    private val encounters: Flow<List<Encounter>> = encounterRepository.findByParty(partyId)
+
+    val notCompletedEncounters: Flow<List<Encounter>> =
+        encounters.map { items -> items.filter { !it.completed } }
+            .distinctUntilChanged()
+
+    val allEncounters: Flow<List<Encounter>> =
+        encounters.distinctUntilChanged()
+            .map { items -> items.sortedBy { it.name } }
 
     suspend fun createEncounter(name: String, description: String) {
         val encounterId = UUID.randomUUID()

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/domain/Encounter.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/domain/Encounter.kt
@@ -13,7 +13,6 @@ data class Encounter(
     val name: String,
     val description: String,
     val position: Int,
-    @Suppress("unused") // This will be introduced in UI in future
     val completed: Boolean = false,
     val characters: Map<LocalCharacterId, Int> = emptyMap(),
 ) {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -161,7 +161,9 @@ data class DrawerStrings(
 @Immutable
 data class EncounterStrings(
     val buttonAdd: String = "Add encounter",
+    val buttonShowCompleted: String = "Show Completed",
     val labelName: String = "Name",
+    val labelCompleted: String = "Completed",
     val labelDescription: String = "Description (Optional)",
     val messages: EncounterMessageStrings = EncounterMessageStrings(),
     val title: String = "Encounters",


### PR DESCRIPTION
This builds upon something that has been dormant since the first implementation of Encounters.

GMs can now mark the Encounter as *Completed*, which will by default hide them from the Encounters list.
This means that GM can now hide old Encounters without outright deleting them.