### PR TITLE
Show back button instead of hamburger on Desktop

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/buttons/HamburgerButton.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/buttons/HamburgerButton.kt
@@ -5,10 +5,22 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Menu
 import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import cz.frantisekmasa.wfrp_master.common.core.LocalStaticConfiguration
+import cz.frantisekmasa.wfrp_master.common.core.config.Platform
 import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 
 @Composable
 fun HamburgerButton() {
+    if (
+        LocalStaticConfiguration.current.platform == Platform.Desktop &&
+        LocalNavigator.currentOrThrow.canPop
+    ) {
+        BackButton()
+        return
+    }
+
     val callback = LocalHamburgerButtonHandler.current
     IconButton(onClick = callback) {
         Icon(


### PR DESCRIPTION
This makes the Desktop app more usable, previously certain screens didn't allow navigating back (Character detail, Encounters).

This is ok on Android as there is HW/SW back button, but the desktop does not have such functionality.