### PR TITLE
Editable Character Note + markdown and UI improvements

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/ambitions/AmbitionsCard.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/ambitions/AmbitionsCard.kt
@@ -1,6 +1,5 @@
 package cz.frantisekmasa.wfrp_master.common.ambitions
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -27,6 +26,7 @@ import cz.frantisekmasa.wfrp_master.common.core.domain.Ambitions
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
 import cz.frantisekmasa.wfrp_master.common.core.shared.drawableResource
 import cz.frantisekmasa.wfrp_master.common.core.ui.cards.CardContainer
+import cz.frantisekmasa.wfrp_master.common.core.ui.cards.CardEditButton
 import cz.frantisekmasa.wfrp_master.common.core.ui.cards.CardTitle
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.VisualOnlyIconDescription
 import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
@@ -53,14 +53,16 @@ fun AmbitionsCard(
     CardContainer(
         modifier = Modifier
             .fillMaxWidth()
-            .then(
-                if (onSave != null)
-                    modifier.clickable(onClick = { dialogOpened = true })
-                else modifier
-            ),
+            .then(modifier),
         bodyPadding = PaddingValues(start = 8.dp, end = 8.dp),
     ) {
-        CardTitle(title, titleIcon)
+        CardTitle(
+            title,
+            titleIcon,
+            actions = if (onSave != null)
+                ({ CardEditButton(onClick = { dialogOpened = true }) })
+            else null
+        )
 
         val strings = LocalStrings.current.ambition
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/notes/EditNoteDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/notes/EditNoteDialog.kt
@@ -73,6 +73,7 @@ fun EditNoteDialog(
                     validate = false,
                     maxLength = Character.NOTE_MAX_LENGTH,
                     multiLine = true,
+                    helperText = LocalStrings.current.commonUi.markdownSupportedNote,
                 )
             }
         }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/notes/EditNoteDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/notes/EditNoteDialog.kt
@@ -1,0 +1,80 @@
+package cz.frantisekmasa.wfrp_master.common.character.notes
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import cz.frantisekmasa.wfrp_master.common.character.CharacterScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
+import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.CloseButton
+import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.FullScreenDialog
+import cz.frantisekmasa.wfrp_master.common.core.ui.forms.TextInput
+import cz.frantisekmasa.wfrp_master.common.core.ui.forms.inputValue
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.SaveAction
+import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@Composable
+fun EditNoteDialog(
+    character: Character,
+    screenModel: CharacterScreenModel,
+    onDismissRequest: () -> Unit,
+) {
+    FullScreenDialog(onDismissRequest = onDismissRequest) {
+        val note = inputValue(character.note)
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    navigationIcon = { CloseButton(onClick = onDismissRequest) },
+                    title = { Text(LocalStrings.current.character.titleEditNote) },
+                    actions = {
+                        val coroutineScope = rememberCoroutineScope()
+                        var saving by remember { mutableStateOf(false) }
+
+                        SaveAction(
+                            enabled = !saving,
+                            onClick = {
+                                saving = true
+
+                                coroutineScope.launch(Dispatchers.IO) {
+                                    screenModel.update { it.copy(note = note.value) }
+
+                                    onDismissRequest()
+                                }
+                            }
+                        )
+                    }
+                )
+            },
+        ) {
+            Column(
+                Modifier
+                    .verticalScroll(rememberScrollState())
+                    .padding(Spacing.bodyPadding),
+                verticalArrangement = Arrangement.spacedBy(Spacing.small),
+            ) {
+                TextInput(
+                    label = LocalStrings.current.character.note,
+                    value = note,
+                    validate = false,
+                    maxLength = Character.NOTE_MAX_LENGTH,
+                    multiLine = true,
+                )
+            }
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/notes/NotesScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/notes/NotesScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Group
 import androidx.compose.runtime.Composable
@@ -17,6 +16,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import com.halilibo.richtext.markdown.Markdown
+import com.halilibo.richtext.ui.RichText
 import cz.frantisekmasa.wfrp_master.common.ambitions.AmbitionsCard
 import cz.frantisekmasa.wfrp_master.common.character.CharacterScreenModel
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
@@ -64,7 +65,10 @@ fun NotesScreen(
                             CardEditButton(onClick = { editNoteDialogOpened = true })
                         }
                     )
-                    Text(character.note)
+
+                    RichText {
+                        Markdown(character.note)
+                    }
                 }
             }
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/notes/NotesScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/notes/NotesScreen.kt
@@ -12,12 +12,17 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Group
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import cz.frantisekmasa.wfrp_master.common.ambitions.AmbitionsCard
 import cz.frantisekmasa.wfrp_master.common.character.CharacterScreenModel
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterType
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.Party
+import cz.frantisekmasa.wfrp_master.common.core.ui.cards.CardEditButton
 import cz.frantisekmasa.wfrp_master.common.core.ui.cards.CardTitle
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.CardRow
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
@@ -43,7 +48,22 @@ fun NotesScreen(
         ) {
             CardRow {
                 Column {
-                    CardTitle(LocalStrings.current.character.note)
+                    var editNoteDialogOpened by remember { mutableStateOf(false) }
+
+                    if (editNoteDialogOpened) {
+                        EditNoteDialog(
+                            character,
+                            screenModel,
+                            onDismissRequest = { editNoteDialogOpened = false },
+                        )
+                    }
+
+                    CardTitle(
+                        LocalStrings.current.character.note,
+                        actions = {
+                            CardEditButton(onClick = { editNoteDialogOpened = true })
+                        }
+                    )
                     Text(character.note)
                 }
             }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/trappings/InventoryItemDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/trappings/InventoryItemDialog.kt
@@ -97,6 +97,7 @@ fun InventoryItemDialog(
                 validate = validate,
                 maxLength = InventoryItem.DESCRIPTION_MAX_LENGTH,
                 multiLine = true,
+                helperText = LocalStrings.current.commonUi.markdownSupportedNote,
             )
 
             TrappingTypeForm(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/blessing/BlessingDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/blessing/BlessingDialog.kt
@@ -73,6 +73,7 @@ fun BlessingDialog(
                 validate = validate,
                 maxLength = Blessing.EFFECT_MAX_LENGTH,
                 multiLine = true,
+                helperText = LocalStrings.current.commonUi.markdownSupportedNote,
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerFormDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerFormDialog.kt
@@ -53,6 +53,7 @@ fun CareerFormDialog(
                 multiLine = true,
                 validate = validate,
                 maxLength = Career.DESCRIPTION_MAX_LENGTH,
+                helperText = LocalStrings.current.commonUi.markdownSupportedNote,
             )
 
             SelectBox(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/miracle/MiracleDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/miracle/MiracleDialog.kt
@@ -80,6 +80,7 @@ fun MiracleDialog(
                 validate = validate,
                 maxLength = Miracle.EFFECT_MAX_LENGTH,
                 multiLine = true,
+                helperText = LocalStrings.current.commonUi.markdownSupportedNote,
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/skill/SkillDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/skill/SkillDialog.kt
@@ -62,6 +62,7 @@ fun SkillDialog(
                 validate = validate,
                 maxLength = Skill.DESCRIPTION_MAX_LENGTH,
                 multiLine = true,
+                helperText = LocalStrings.current.commonUi.markdownSupportedNote,
             )
 
             ChipList(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellDialog.kt
@@ -91,6 +91,7 @@ fun SpellDialog(
                 validate = validate,
                 maxLength = Spell.EFFECT_MAX_LENGTH,
                 multiLine = true,
+                helperText = LocalStrings.current.commonUi.markdownSupportedNote,
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentDialog.kt
@@ -66,6 +66,7 @@ fun TalentDialog(
                 validate = validate,
                 maxLength = Talent.DESCRIPTION_MAX_LENGTH,
                 multiLine = true,
+                helperText = LocalStrings.current.commonUi.markdownSupportedNote,
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trait/TraitDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trait/TraitDialog.kt
@@ -59,6 +59,7 @@ fun TraitDialog(
                 validate = validate,
                 maxLength = Trait.DESCRIPTION_MAX_LENGTH,
                 multiLine = true,
+                helperText = LocalStrings.current.commonUi.markdownSupportedNote,
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/cards/CardEditButton.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/cards/CardEditButton.kt
@@ -1,0 +1,20 @@
+package cz.frantisekmasa.wfrp_master.common.core.ui.cards
+
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Edit
+import androidx.compose.runtime.Composable
+import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
+
+@Composable
+fun CardEditButton(onClick: () -> Unit) {
+    IconButton(onClick = onClick) {
+        Icon(
+            Icons.Rounded.Edit,
+            LocalStrings.current.commonUi.buttonEdit,
+            tint = MaterialTheme.colors.primary,
+        )
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -323,6 +323,7 @@ data class CharacterStrings(
     val titleCareer: String = "Career",
     val titleCharacteristics: String = "Characteristics",
     val titleEdit: String = "Edit Character",
+    val titleEditNote: String = "Edit Note",
     val titleExperience: String = "Experience",
     val titleGeneralSettings: String = "General",
     val titleRemoval: String = "Remove Character",

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -428,6 +428,7 @@ data class CommonUiStrings(
     val labelOpenDrawer: String = "Open navigation drawer",
     val labelOpenContextMenu: String = "Open context menu",
     val labelPreviousScreen: String = "Return to previous screen",
+    val markdownSupportedNote: String = "Markdown formatting is supported",
     val decrement: String = "Decrement value",
     val increment: String = "Increment value",
     val itemNone: String = "None",


### PR DESCRIPTION
- Character Note can now be edited from Character detail
- Both Character Note and Ambitions use same UI pattern (Pencil button in top right corner) for editing. This should make it obvious that the value can be changed.
- I also changed Character Note rendering to support markdown and added "Markdown formatting is supported" helper text to all relevant text fields