### PR TITLE
Compendium item visiblity

### DIFF
--- a/app/src/main/kotlin/cz/muni/fi/rpg/ui/shell/Startup.kt
+++ b/app/src/main/kotlin/cz/muni/fi/rpg/ui/shell/Startup.kt
@@ -2,18 +2,20 @@ package cz.muni.fi.rpg.ui.shell
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import cz.frantisekmasa.wfrp_master.common.auth.LocalAuthenticationManager
+import cz.frantisekmasa.wfrp_master.common.auth.AuthenticationManager
 import cz.frantisekmasa.wfrp_master.common.core.auth.LocalUser
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
 import cz.muni.fi.rpg.ui.startup.StartupScreen
+import org.kodein.di.compose.localDI
+import org.kodein.di.instance
 
 @Composable
 fun Startup(content: @Composable () -> Unit) {
-    val auth = LocalAuthenticationManager.current
+    val auth: AuthenticationManager by localDI().instance()
     val user = auth.user.collectWithLifecycle().value
 
     if (user == null) {
-        StartupScreen()
+        StartupScreen(auth)
         return
     }
 

--- a/app/src/main/kotlin/cz/muni/fi/rpg/ui/startup/StartupScreen.kt
+++ b/app/src/main/kotlin/cz/muni/fi/rpg/ui/startup/StartupScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import com.google.android.gms.auth.api.signin.GoogleSignIn
-import cz.frantisekmasa.wfrp_master.common.auth.LocalAuthenticationManager
+import cz.frantisekmasa.wfrp_master.common.auth.AuthenticationManager
 import cz.frantisekmasa.wfrp_master.common.auth.LocalWebClientId
 import cz.frantisekmasa.wfrp_master.common.core.shared.SettingsStorage
 import cz.frantisekmasa.wfrp_master.common.core.shared.edit
@@ -32,10 +32,8 @@ import org.kodein.di.compose.localDI
 import org.kodein.di.instance
 
 @Composable
-fun StartupScreen() {
+fun StartupScreen(authenticationManager: AuthenticationManager) {
     SplashScreen()
-
-    val authenticationManager = LocalAuthenticationManager.current
 
     val authenticated by authenticationManager.authenticated.collectWithLifecycle()
 

--- a/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/DependencyInjection.kt
+++ b/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/DependencyInjection.kt
@@ -7,6 +7,7 @@ import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.firestore.ktx.firestoreSettings
 import com.google.firebase.functions.ktx.functions
 import com.google.firebase.ktx.Firebase
+import cz.frantisekmasa.wfrp_master.common.auth.AuthenticationManager
 import cz.frantisekmasa.wfrp_master.common.core.shared.SettingsStorage
 import cz.frantisekmasa.wfrp_master.common.firebase.firestore.Firestore
 import cz.frantisekmasa.wfrp_master.common.firebase.functions.CloudFunctions
@@ -35,6 +36,8 @@ actual val platformModule = DI.Module("android") {
 
         Firestore(firestore)
     }
+
+    bindSingleton { AuthenticationManager(instance()) }
 
     bindSingleton {
         val functions = Firebase.functions

--- a/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/auth/AuthenticationManager.kt
+++ b/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/auth/AuthenticationManager.kt
@@ -9,9 +9,9 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthUserCollisionException
 import com.google.firebase.auth.GoogleAuthProvider
-import com.google.firebase.auth.ktx.auth
-import com.google.firebase.ktx.Firebase
 import cz.frantisekmasa.wfrp_master.common.core.auth.User
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserProvider
 import cz.frantisekmasa.wfrp_master.common.core.logging.Reporter
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
@@ -25,10 +25,9 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
-val LocalAuthenticationManager = staticCompositionLocalOf { AuthenticationManager(Firebase.auth) }
 val LocalWebClientId = staticCompositionLocalOf<String> { error("LocalWebTokenId was not set") }
 
-class AuthenticationManager(private val auth: FirebaseAuth) {
+class AuthenticationManager(private val auth: FirebaseAuth) : UserProvider {
     val coroutineScope = CoroutineScope(Dispatchers.Default)
 
     val authenticated: StateFlow<Boolean?> = callbackFlow {
@@ -67,6 +66,8 @@ class AuthenticationManager(private val auth: FirebaseAuth) {
             email = if (it.email == "") null else it.email
         )
     }.stateIn(coroutineScope, SharingStarted.Eagerly, null)
+
+    override val userId: UserId? get() = user.value?.id?.let(::UserId)
 
     init {
         coroutineScope.launch {

--- a/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/auth/AuthenticationManager.kt
+++ b/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/auth/AuthenticationManager.kt
@@ -62,12 +62,12 @@ class AuthenticationManager(private val auth: FirebaseAuth) : UserProvider {
         awaitClose { auth.removeAuthStateListener(listener) }
     }.map {
         User(
-            id = it.uid,
+            id = UserId(it.uid),
             email = if (it.email == "") null else it.email
         )
     }.stateIn(coroutineScope, SharingStarted.Eagerly, null)
 
-    override val userId: UserId? get() = user.value?.id?.let(::UserId)
+    override val userId: UserId? get() = user.value?.id
 
     init {
         coroutineScope.launch {

--- a/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/logging/Reporter.kt
+++ b/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/logging/Reporter.kt
@@ -4,12 +4,13 @@ import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.ktx.Firebase
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 
 actual object Reporter {
     private val crashlytics by lazy { FirebaseCrashlytics.getInstance() }
 
-    actual fun setUserId(id: String) {
-        crashlytics.setUserId(id)
+    actual fun setUserId(id: UserId) {
+        crashlytics.setUserId(id.toString())
     }
 
     actual fun log(message: String) {

--- a/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/settings/SignInCard.kt
+++ b/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/settings/SignInCard.kt
@@ -36,7 +36,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.firebase.auth.FirebaseAuthUserCollisionException
-import cz.frantisekmasa.wfrp_master.common.auth.LocalAuthenticationManager
+import cz.frantisekmasa.wfrp_master.common.auth.AuthenticationManager
 import cz.frantisekmasa.wfrp_master.common.auth.LocalWebClientId
 import cz.frantisekmasa.wfrp_master.common.core.auth.LocalUser
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
@@ -56,10 +56,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
+import org.kodein.di.compose.localDI
+import org.kodein.di.instance
 
 @Composable
 actual fun SignInCard(settingsScreenModel: SettingsScreenModel) {
-    val authManager = LocalAuthenticationManager.current
+    val authManager: AuthenticationManager by localDI().instance()
     val webClientId = LocalWebClientId.current
     val contract = remember(authManager) { authManager.googleSignInContract(webClientId) }
     val context = LocalContext.current
@@ -69,6 +71,7 @@ actual fun SignInCard(settingsScreenModel: SettingsScreenModel) {
 
     pendingSingInConfirmation?.let {
         ConfirmSignInDialog(
+            authManager,
             it.idToken,
             settingsScreenModel,
             onDismissRequest = { pendingSingInConfirmation = null },
@@ -151,11 +154,11 @@ actual fun SignInCard(settingsScreenModel: SettingsScreenModel) {
 
 @Composable
 fun ConfirmSignInDialog(
+    authManager: AuthenticationManager,
     idToken: String,
     screenModel: SettingsScreenModel,
     onDismissRequest: () -> Unit,
 ) {
-    val authManager = LocalAuthenticationManager.current
     val coroutineScope = rememberCoroutineScope()
     val userId = LocalUser.current.id
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/DependencyInjection.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/DependencyInjection.kt
@@ -172,6 +172,8 @@ val appModule = DI.Module("Common") {
             instance(),
             instance(),
             instance(),
+            instance(),
+            instance(),
         )
     }
     bindFactory { partyId: PartyId -> CharacterPickerScreenModel(partyId, instance()) }
@@ -181,19 +183,27 @@ val appModule = DI.Module("Common") {
         EncounterDetailScreenModel(encounterId, instance(), instance(), instance(), instance())
     }
     bindFactory { characterId: CharacterId ->
-        SkillsScreenModel(characterId, instance(), instance())
+        SkillsScreenModel(characterId, instance(), instance(), instance(), instance())
     }
     bindFactory { characterId: CharacterId ->
-        SpellsScreenModel(characterId, instance(), instance())
+        SpellsScreenModel(characterId, instance(), instance(), instance(), instance())
     }
     bindFactory { characterId: CharacterId ->
-        TalentsScreenModel(characterId, instance(), instance(), instance(), instance())
+        TalentsScreenModel(
+            characterId,
+            instance(),
+            instance(),
+            instance(),
+            instance(),
+            instance(),
+            instance(),
+        )
     }
     bindFactory { characterId: CharacterId ->
-        MiraclesScreenModel(characterId, instance(), instance())
+        MiraclesScreenModel(characterId, instance(), instance(), instance(), instance())
     }
     bindFactory { characterId: CharacterId ->
-        BlessingsScreenModel(characterId, instance(), instance())
+        BlessingsScreenModel(characterId, instance(), instance(), instance(), instance())
     }
 
     bindFactory { partyId: PartyId ->
@@ -220,7 +230,15 @@ val appModule = DI.Module("Common") {
 
     bindSingleton { EffectManager(instance(), instance(), instance()) }
     bindFactory { characterId: CharacterId ->
-        TraitsScreenModel(characterId, instance(), instance(), instance(), instance())
+        TraitsScreenModel(
+            characterId,
+            instance(),
+            instance(),
+            instance(),
+            instance(),
+            instance(),
+            instance(),
+        )
     }
     bindProvider { InvitationScreenModel(instance(), instance(), instance()) }
     bindProvider { PartyListScreenModel(instance()) }
@@ -229,7 +247,9 @@ val appModule = DI.Module("Common") {
         CharacterCreationScreenModel(
             partyId,
             instance(),
-            instance()
+            instance(),
+            instance(),
+            instance(),
         )
     }
     bindFactory { partyId: PartyId ->

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CharacterDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CharacterDetailScreen.kt
@@ -44,7 +44,6 @@ import cz.frantisekmasa.wfrp_master.common.combat.ActiveCombatBanner
 import cz.frantisekmasa.wfrp_master.common.core.LocalStaticConfiguration
 import cz.frantisekmasa.wfrp_master.common.core.PartyScreenModel
 import cz.frantisekmasa.wfrp_master.common.core.auth.LocalUser
-import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.config.Platform
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterTab
@@ -142,8 +141,8 @@ data class CharacterDetailScreen(
     ) {
         val characterPickerScreenModel: CharacterPickerScreenModel =
             rememberScreenModel(arg = party.id)
-        val userId = UserId(LocalUser.current.id)
-        val isGameMaster = party.gameMasterId == null || party.gameMasterId == userId.toString()
+        val userId = LocalUser.current.id
+        val isGameMaster = party.gameMasterId == null || party.gameMasterId == userId
         val canAddCharacters = !isGameMaster
 
         val allCharacters = remember {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CharacterPickerScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CharacterPickerScreen.kt
@@ -14,7 +14,6 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cz.frantisekmasa.wfrp_master.common.characterCreation.CharacterCreationScreen
 import cz.frantisekmasa.wfrp_master.common.core.auth.LocalUser
-import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterType
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
@@ -34,7 +33,7 @@ data class CharacterPickerScreen(
     @Composable
     override fun Content() {
         val screenModel: CharacterPickerScreenModel = rememberScreenModel(arg = partyId)
-        val userId = UserId(LocalUser.current.id)
+        val userId = LocalUser.current.id
 
         val characters = remember { screenModel.allUserCharacters(userId) }
             .collectWithLifecycle(null).value

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CharacterPickerScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CharacterPickerScreenModel.kt
@@ -16,7 +16,7 @@ class CharacterPickerScreenModel(
     fun allUserCharacters(userId: UserId): Flow<List<Character>> {
         return characters.inParty(partyId, CharacterType.PLAYER_CHARACTER).map {
             it.filter { character ->
-                character.userId == userId.toString() || character.id == userId.toString()
+                character.userId == userId || character.id == userId.toString()
             }
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/religion/blessings/BlessingsScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/religion/blessings/BlessingsScreenModel.kt
@@ -1,8 +1,10 @@
 package cz.frantisekmasa.wfrp_master.common.character.religion.blessings
 
 import cz.frantisekmasa.wfrp_master.common.core.CharacterItemScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserProvider
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.Compendium
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
+import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.religion.Blessing
 import cz.frantisekmasa.wfrp_master.common.core.domain.religion.BlessingRepository
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Blessing as CompendiumBlessing
@@ -11,4 +13,12 @@ class BlessingsScreenModel(
     characterId: CharacterId,
     repository: BlessingRepository,
     compendium: Compendium<CompendiumBlessing>,
-) : CharacterItemScreenModel<Blessing, CompendiumBlessing>(characterId, repository, compendium)
+    userProvider: UserProvider,
+    partyRepository: PartyRepository,
+) : CharacterItemScreenModel<Blessing, CompendiumBlessing>(
+    characterId,
+    repository,
+    compendium,
+    userProvider,
+    partyRepository,
+)

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/religion/miracles/MiraclesScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/religion/miracles/MiraclesScreenModel.kt
@@ -1,8 +1,10 @@
 package cz.frantisekmasa.wfrp_master.common.character.religion.miracles
 
 import cz.frantisekmasa.wfrp_master.common.core.CharacterItemScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserProvider
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.Compendium
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
+import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.religion.Miracle
 import cz.frantisekmasa.wfrp_master.common.core.domain.religion.MiracleRepository
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Miracle as CompendiumMiracle
@@ -11,4 +13,12 @@ class MiraclesScreenModel(
     characterId: CharacterId,
     repository: MiracleRepository,
     compendium: Compendium<CompendiumMiracle>,
-) : CharacterItemScreenModel<Miracle, CompendiumMiracle>(characterId, repository, compendium)
+    userProvider: UserProvider,
+    partyRepository: PartyRepository,
+) : CharacterItemScreenModel<Miracle, CompendiumMiracle>(
+    characterId,
+    repository,
+    compendium,
+    userProvider,
+    partyRepository,
+)

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/skills/SkillsScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/skills/SkillsScreenModel.kt
@@ -4,8 +4,10 @@ import cafe.adriel.voyager.core.model.coroutineScope
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 import cz.frantisekmasa.wfrp_master.common.core.CharacterItemScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserProvider
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.Compendium
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
+import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.skills.Skill
 import cz.frantisekmasa.wfrp_master.common.core.domain.skills.SkillRepository
 import io.github.aakira.napier.Napier
@@ -19,7 +21,15 @@ class SkillsScreenModel(
     private val characterId: CharacterId,
     private val skillRepository: SkillRepository,
     private val compendium: Compendium<CompendiumSkill>,
-) : CharacterItemScreenModel<Skill, CompendiumSkill>(characterId, skillRepository, compendium) {
+    userProvider: UserProvider,
+    partyRepository: PartyRepository,
+) : CharacterItemScreenModel<Skill, CompendiumSkill>(
+    characterId,
+    skillRepository,
+    compendium,
+    userProvider,
+    partyRepository,
+) {
 
     suspend fun saveSkill(skill: Skill) = skillRepository.save(characterId, skill)
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/spells/SpellsScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/spells/SpellsScreenModel.kt
@@ -2,7 +2,9 @@ package cz.frantisekmasa.wfrp_master.common.character.spells
 
 import cafe.adriel.voyager.core.model.coroutineScope
 import cz.frantisekmasa.wfrp_master.common.core.CharacterItemScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserProvider
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.Compendium
+import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.spells.Spell
 import cz.frantisekmasa.wfrp_master.common.core.domain.spells.SpellRepository
 import cz.frantisekmasa.wfrp_master.common.core.shared.IO
@@ -13,8 +15,16 @@ import cz.frantisekmasa.wfrp_master.common.compendium.domain.Spell as Compendium
 class SpellsScreenModel(
     private val characterId: cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId,
     private val spellRepository: SpellRepository,
+    userProvider: UserProvider,
+    partyRepository: PartyRepository,
     compendium: Compendium<CompendiumSpell>
-) : CharacterItemScreenModel<Spell, CompendiumSpell>(characterId, spellRepository, compendium) {
+) : CharacterItemScreenModel<Spell, CompendiumSpell>(
+    characterId,
+    spellRepository,
+    compendium,
+    userProvider,
+    partyRepository,
+) {
     suspend fun saveSpell(spell: Spell) {
         spellRepository.save(characterId, spell)
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/TalentsScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/TalentsScreenModel.kt
@@ -5,8 +5,10 @@ import com.benasher44.uuid.Uuid
 import cz.frantisekmasa.wfrp_master.common.character.effects.EffectManager
 import cz.frantisekmasa.wfrp_master.common.character.effects.EffectSource
 import cz.frantisekmasa.wfrp_master.common.core.CharacterItemScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserProvider
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.Compendium
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
+import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.talents.Talent
 import cz.frantisekmasa.wfrp_master.common.core.domain.talents.TalentRepository
 import cz.frantisekmasa.wfrp_master.common.core.shared.IO
@@ -21,7 +23,15 @@ class TalentsScreenModel(
     private val compendium: Compendium<CompendiumTalent>,
     private val effectManager: EffectManager,
     private val firestore: Firestore,
-) : CharacterItemScreenModel<Talent, CompendiumTalent>(characterId, talentRepository, compendium) {
+    userProvider: UserProvider,
+    partyRepository: PartyRepository,
+) : CharacterItemScreenModel<Talent, CompendiumTalent>(
+    characterId,
+    talentRepository,
+    compendium,
+    userProvider,
+    partyRepository,
+) {
 
     suspend fun saveTalent(talent: Talent) {
         firestore.runTransaction { transaction ->

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/traits/TraitsScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/traits/TraitsScreenModel.kt
@@ -5,8 +5,10 @@ import com.benasher44.uuid.Uuid
 import cz.frantisekmasa.wfrp_master.common.character.effects.EffectManager
 import cz.frantisekmasa.wfrp_master.common.character.effects.EffectSource
 import cz.frantisekmasa.wfrp_master.common.core.CharacterItemScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserProvider
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.Compendium
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
+import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.traits.Trait
 import cz.frantisekmasa.wfrp_master.common.core.domain.traits.TraitRepository
 import cz.frantisekmasa.wfrp_master.common.core.shared.IO
@@ -21,7 +23,15 @@ class TraitsScreenModel(
     private val compendium: Compendium<CompendiumTrait>,
     private val effectManager: EffectManager,
     private val firestore: Firestore,
-) : CharacterItemScreenModel<Trait, CompendiumTrait>(characterId, traitRepository, compendium) {
+    userProvider: UserProvider,
+    partyRepository: PartyRepository,
+) : CharacterItemScreenModel<Trait, CompendiumTrait>(
+    characterId,
+    traitRepository,
+    compendium,
+    userProvider,
+    partyRepository,
+) {
 
     fun removeTrait(trait: Trait) = coroutineScope.launch(Dispatchers.IO) {
         firestore.runTransaction { transaction ->

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterCreation/CharacterCreationScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterCreation/CharacterCreationScreenModel.kt
@@ -50,7 +50,7 @@ class CharacterCreationScreenModel(
                         type = type,
                         name = info.name.value,
                         publicName = info.publicName.value.takeIf { it.isNotBlank() },
-                        userId = userId?.toString(),
+                        userId = userId,
                         career = if (career is SelectedCareer.NonCompendiumCareer) career.careerName else "",
                         socialClass = if (career is SelectedCareer.NonCompendiumCareer) career.socialClass else "",
                         status = info.status.value,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/ActiveCombatScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/combat/ActiveCombatScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.rounded.ArrowForward
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -56,6 +57,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import cz.frantisekmasa.wfrp_master.common.character.CharacterDetailScreen
 import cz.frantisekmasa.wfrp_master.common.character.conditions.ConditionIcon
 import cz.frantisekmasa.wfrp_master.common.core.auth.LocalUser
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.combat.Advantage
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.combat.GroupAdvantage
@@ -275,7 +277,8 @@ class ActiveCombatScreen(
         }
     }
 
-    private fun canEditCombatant(userId: String, isGameMaster: Boolean, combatant: CombatantItem) =
+    @Stable
+    private fun canEditCombatant(userId: UserId, isGameMaster: Boolean, combatant: CombatantItem) =
         isGameMaster || (combatant is CombatantItem.Character && combatant.userId == userId)
 
     @Composable

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CompendiumItemDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CompendiumItemDetailScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import arrow.core.Either
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -45,7 +44,9 @@ fun <A : CompendiumItem<A>> Screen.CompendiumItemDetailScreen(
 
     val navigator = LocalNavigator.currentOrThrow
 
-    if (itemOrError !is Either.Right<A>) {
+    val item = itemOrError.orNull()
+
+    if (item == null) {
         val message = LocalStrings.current.compendium.messages.itemDoesNotExist
         val snackbarHolder = LocalPersistentSnackbarHolder.current
 
@@ -59,14 +60,14 @@ fun <A : CompendiumItem<A>> Screen.CompendiumItemDetailScreen(
     var editDialogOpened by remember { mutableStateOf(false) }
 
     if (editDialogOpened) {
-        editDialog(itemOrError.value) { editDialogOpened = false }
+        editDialog(item) { editDialogOpened = false }
     }
 
     Scaffold(
         topBar = {
             TopAppBar(
                 navigationIcon = { BackButton() },
-                title = { Text(itemOrError.value.name) },
+                title = { Text(item.name) },
                 actions = {
                     IconAction(
                         Icons.Rounded.Edit,
@@ -78,7 +79,12 @@ fun <A : CompendiumItem<A>> Screen.CompendiumItemDetailScreen(
         }
     ) {
         Column(Modifier.verticalScroll(rememberScrollState())) {
-            detail(itemOrError.value)
+            VisibilitySwitchBar(
+                visible = item.isVisibleToPlayers,
+                onChange = { screenModel.update(item.changeVisibility(it)) },
+            )
+
+            detail(item)
         }
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/VisibilityIcon.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/VisibilityIcon.kt
@@ -1,0 +1,31 @@
+package cz.frantisekmasa.wfrp_master.common.compendium
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Visibility
+import androidx.compose.material.icons.rounded.VisibilityOff
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.CompendiumItem
+import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
+
+@Composable
+fun VisibilityIcon(item: CompendiumItem<*>) {
+    val modifier = Modifier.size(16.dp)
+
+    if (item.isVisibleToPlayers) {
+        Icon(
+            Icons.Rounded.Visibility,
+            LocalStrings.current.compendium.visibleToPlayersTrue,
+            modifier = modifier,
+        )
+    } else {
+        Icon(
+            Icons.Rounded.VisibilityOff,
+            LocalStrings.current.compendium.visibleToPlayersFalse,
+            modifier = modifier,
+        )
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/VisibilitySwitchBar.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/VisibilitySwitchBar.kt
@@ -1,0 +1,72 @@
+package cz.frantisekmasa.wfrp_master.common.compendium
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Visibility
+import androidx.compose.material.icons.rounded.VisibilityOff
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.SubheadBar
+import cz.frantisekmasa.wfrp_master.common.core.utils.launchLogged
+import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
+import kotlinx.coroutines.Dispatchers
+
+@Composable
+fun VisibilitySwitchBar(visible: Boolean, onChange: suspend (Boolean) -> Unit) {
+    SubheadBar {
+        Row(
+            Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    if (visible) Icons.Rounded.Visibility else Icons.Rounded.VisibilityOff,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = Spacing.small),
+                )
+
+                Text(
+                    if (visible)
+                        LocalStrings.current.compendium.visibleToPlayersTrue
+                    else LocalStrings.current.compendium.visibleToPlayersFalse
+                )
+            }
+
+            val coroutineScope = rememberCoroutineScope()
+
+            val (saving, setSaving) = remember { mutableStateOf(false) }
+
+            Switch(
+                checked = visible,
+                enabled = !saving,
+                onCheckedChange = {
+                    if (saving) {
+                        return@Switch
+                    }
+
+                    coroutineScope.launchLogged(Dispatchers.IO) {
+                        setSaving(true)
+
+                        try {
+                            onChange(!visible)
+                        } finally {
+                            setSaving(false)
+                        }
+                    }
+                }
+            )
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/blessing/BlessingCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/blessing/BlessingCompendiumTab.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.Dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cz.frantisekmasa.wfrp_master.common.compendium.CompendiumTab
+import cz.frantisekmasa.wfrp_master.common.compendium.VisibilityIcon
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.EmptyUI
@@ -21,18 +22,19 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 @Composable
 fun BlessingCompendiumTab(partyId: PartyId, screenModel: BlessingCompendiumScreenModel, width: Dp) {
     val messages = LocalStrings.current.blessings.messages
-
     var newBlessingDialogOpened by rememberSaveable { mutableStateOf(false) }
+    val navigator = LocalNavigator.currentOrThrow
 
     if (newBlessingDialogOpened) {
         BlessingDialog(
             blessing = null,
-            screenModel,
             onDismissRequest = { newBlessingDialogOpened = false },
+            onSaveRequest = {
+                screenModel.createNew(it)
+                navigator.push(BlessingDetailScreen(partyId, it.id))
+            },
         )
     }
-
-    val navigator = LocalNavigator.currentOrThrow
 
     CompendiumTab(
         liveItems = screenModel.items,
@@ -51,7 +53,8 @@ fun BlessingCompendiumTab(partyId: PartyId, screenModel: BlessingCompendiumScree
     ) { blessing ->
         ListItem(
             icon = { ItemIcon(Resources.Drawable.Blessing) },
-            text = { Text(blessing.name) }
+            text = { Text(blessing.name) },
+            trailing = { VisibilityIcon(blessing) },
         )
         Divider()
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/blessing/BlessingDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/blessing/BlessingDetailScreen.kt
@@ -31,7 +31,7 @@ class BlessingDetailScreen(
             BlessingDialog(
                 blessing = item,
                 onDismissRequest = onDismissRequest,
-                screenModel = screenModel,
+                onSaveRequest = screenModel::update,
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/blessing/BlessingDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/blessing/BlessingDialog.kt
@@ -23,8 +23,8 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 @Composable
 fun BlessingDialog(
     blessing: Blessing?,
-    screenModel: BlessingCompendiumScreenModel,
     onDismissRequest: () -> Unit,
+    onSaveRequest: suspend (Blessing) -> Unit,
 ) {
     val formData = BlessingFormData.fromItem(blessing)
     val strings = LocalStrings.current.blessings
@@ -32,7 +32,7 @@ fun BlessingDialog(
     CompendiumItemDialog(
         title = if (blessing == null) strings.titleNew else strings.titleEdit,
         formData = formData,
-        saver = if (blessing == null) screenModel::createNew else screenModel::update,
+        saver = onSaveRequest,
         onDismissRequest = onDismissRequest,
     ) { validate ->
         Column(
@@ -87,6 +87,7 @@ private data class BlessingFormData(
     val target: InputValue,
     val duration: InputValue,
     val effect: InputValue,
+    val isVisibleToPlayers: Boolean,
 ) : CompendiumItemFormData<Blessing> {
     companion object {
         @Composable
@@ -97,6 +98,7 @@ private data class BlessingFormData(
             target = inputValue(item?.target ?: ""),
             duration = inputValue(item?.duration ?: ""),
             effect = inputValue(item?.effect ?: ""),
+            isVisibleToPlayers = item?.isVisibleToPlayers ?: false,
         )
     }
 
@@ -107,6 +109,7 @@ private data class BlessingFormData(
         target = target.value,
         duration = duration.value,
         effect = effect.value,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     override fun isValid() =

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerCompendiumTab.kt
@@ -31,7 +31,7 @@ fun CareerCompendiumTab(partyId: PartyId, screenModel: CareerCompendiumScreenMod
         CareerFormDialog(
             title = LocalStrings.current.careers.titleNewCareer,
             existingCareer = null,
-            onSave = {
+            onSaveRequest = {
                 val id = uuid4()
                 screenModel.createNew(
                     Career(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerDetailScreen.kt
@@ -40,13 +40,13 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import com.benasher44.uuid.Uuid
 import com.halilibo.richtext.markdown.Markdown
 import com.halilibo.richtext.ui.RichText
+import cz.frantisekmasa.wfrp_master.common.compendium.VisibilitySwitchBar
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Career
 import cz.frantisekmasa.wfrp_master.common.core.PartyScreenModel
 import cz.frantisekmasa.wfrp_master.common.core.auth.LocalUser
 import cz.frantisekmasa.wfrp_master.common.core.domain.localizedName
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.Party
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
-import cz.frantisekmasa.wfrp_master.common.core.shared.IO
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelable
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelize
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
@@ -170,7 +170,7 @@ class CareerDetailScreen(
                                     races = career.races,
                                     socialClass = career.socialClass,
                                 ),
-                                onSave = {
+                                onSaveRequest = {
                                     screenModel.update(
                                         career.copy(
                                             name = it.name,
@@ -204,27 +204,34 @@ class CareerDetailScreen(
         ) {
             TabPager(fullWidthTabs = true) {
                 tab(strings.tabDetail) {
-                    LazyColumn(contentPadding = PaddingValues(Spacing.bodyPadding)) {
-                        item {
-                            SingleLineTextValue(
-                                strings.labelSocialClass,
-                                career.socialClass.localizedName,
-                            )
-                        }
+                    Column {
+                        VisibilitySwitchBar(
+                            visible = career.isVisibleToPlayers,
+                            onChange = { screenModel.update(career.changeVisibility(it)) },
+                        )
 
-                        item {
-                            val globalStrings = LocalStrings.current
-                            SingleLineTextValue(
-                                strings.labelRaces,
-                                career.races.joinToString(", ") {
-                                    it.nameResolver(globalStrings)
-                                },
-                            )
-                        }
+                        LazyColumn(contentPadding = PaddingValues(Spacing.bodyPadding)) {
+                            item {
+                                SingleLineTextValue(
+                                    strings.labelSocialClass,
+                                    career.socialClass.localizedName,
+                                )
+                            }
 
-                        item {
-                            RichText {
-                                Markdown(career.description)
+                            item {
+                                val globalStrings = LocalStrings.current
+                                SingleLineTextValue(
+                                    strings.labelRaces,
+                                    career.races.joinToString(", ") {
+                                        it.nameResolver(globalStrings)
+                                    },
+                                )
+                            }
+
+                            item {
+                                RichText {
+                                    Markdown(career.description)
+                                }
                             }
                         }
                     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerDetailScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import arrow.core.Either
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -90,19 +89,23 @@ class CareerDetailScreen(
             return
         }
 
-        when (career) {
-            is Either.Left -> {
-                val snackbarHolder = LocalPersistentSnackbarHolder.current
-                val strings = LocalStrings.current
-                val navigator = LocalNavigator.currentOrThrow
+        val careerValue = career.orNull()
+            ?.takeIf { it.isVisibleToPlayers || party.gameMasterId == LocalUser.current.id }
 
-                LaunchedEffect(Unit) {
-                    snackbarHolder.showSnackbar(strings.careers.messages.notFound)
-                    navigator.pop()
-                }
+        val snackbarHolder = LocalPersistentSnackbarHolder.current
+        val strings = LocalStrings.current
+        val navigator = LocalNavigator.currentOrThrow
+
+        if (careerValue == null) {
+            LaunchedEffect(Unit) {
+                snackbarHolder.showSnackbar(strings.careers.messages.notFound)
+                navigator.pop()
             }
-            is Either.Right -> Detail(career.value, party, screenModel)
+
+            return
         }
+
+        Detail(careerValue, party, screenModel)
     }
 
     private sealed class LevelDialogState : Parcelable {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerFormDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerFormDialog.kt
@@ -26,7 +26,7 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 fun CareerFormDialog(
     title: String,
     existingCareer: CareerData?,
-    onSave: suspend (CareerData) -> Unit,
+    onSaveRequest: suspend (CareerData) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
     val data = CareerFormData.fromCareerData(existingCareer)
@@ -36,7 +36,7 @@ fun CareerFormDialog(
             title = title,
             onDismissRequest = onDismissRequest,
             formData = data,
-            onSave = onSave,
+            onSave = onSaveRequest,
         ) { validate ->
             val strings = LocalStrings.current.careers
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Blessing.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Blessing.kt
@@ -18,6 +18,7 @@ data class Blessing(
     val target: String,
     val duration: String,
     val effect: String,
+    override val isVisibleToPlayers: Boolean = true,
 ) : CompendiumItem<Blessing>() {
     companion object {
         const val NAME_MAX_LENGTH = 50

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Blessing.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Blessing.kt
@@ -27,6 +27,7 @@ data class Blessing(
         const val DURATION_MAX_LENGTH = 50
         const val EFFECT_MAX_LENGTH = 1000
     }
+
     init {
         require(name.isNotBlank()) { "Name must not be blank" }
         name.requireMaxLength(NAME_MAX_LENGTH, "name")
@@ -37,6 +38,9 @@ data class Blessing(
     }
 
     override fun replace(original: Blessing) = copy(id = original.id)
+
+    override fun changeVisibility(isVisibleToPlayers: Boolean) =
+        copy(isVisibleToPlayers = !isVisibleToPlayers)
 
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Career.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Career.kt
@@ -51,6 +51,9 @@ data class Career(
 
     override fun duplicate(): Career = copy(name = duplicateName())
 
+    override fun changeVisibility(isVisibleToPlayers: Boolean) =
+        copy(isVisibleToPlayers = isVisibleToPlayers)
+
     @Parcelize
     @Serializable
     data class Level(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Career.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Career.kt
@@ -19,6 +19,7 @@ data class Career(
     val socialClass: SocialClass,
     val races: Set<Race>,
     val levels: List<Level>,
+    override val isVisibleToPlayers: Boolean = true,
 ) : CompendiumItem<Career>() {
 
     companion object {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/CompendiumItem.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/CompendiumItem.kt
@@ -7,6 +7,7 @@ import cz.frantisekmasa.wfrp_master.common.core.utils.duplicateName
 sealed class CompendiumItem<T : CompendiumItem<T>> : Parcelable {
     abstract val id: Uuid
     abstract val name: String
+    abstract val isVisibleToPlayers: Boolean
 
     abstract fun duplicate(): T
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/CompendiumItem.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/CompendiumItem.kt
@@ -13,5 +13,7 @@ sealed class CompendiumItem<T : CompendiumItem<T>> : Parcelable {
 
     abstract fun replace(original: T): T
 
+    abstract fun changeVisibility(isVisibleToPlayers: Boolean): T
+
     protected fun duplicateName(): String = duplicateName(name)
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Miracle.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Miracle.kt
@@ -19,6 +19,7 @@ data class Miracle(
     val duration: String,
     val effect: String,
     val cultName: String,
+    override val isVisibleToPlayers: Boolean = true,
 ) : CompendiumItem<Miracle>() {
     companion object {
         const val NAME_MAX_LENGTH = 50

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Miracle.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Miracle.kt
@@ -42,4 +42,7 @@ data class Miracle(
     override fun replace(original: Miracle) = copy(id = original.id)
 
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
+
+    override fun changeVisibility(isVisibleToPlayers: Boolean) =
+        copy(isVisibleToPlayers = isVisibleToPlayers)
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Skill.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Skill.kt
@@ -18,6 +18,7 @@ data class Skill(
     val description: String,
     val characteristic: Characteristic,
     val advanced: Boolean,
+    override val isVisibleToPlayers: Boolean = true,
 ) : CompendiumItem<Skill>() {
     companion object {
         const val NAME_MAX_LENGTH = 50

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Skill.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Skill.kt
@@ -34,4 +34,7 @@ data class Skill(
     override fun replace(original: Skill) = copy(id = original.id)
 
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
+
+    override fun changeVisibility(isVisibleToPlayers: Boolean) =
+        copy(isVisibleToPlayers = isVisibleToPlayers)
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Spell.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Spell.kt
@@ -44,4 +44,7 @@ data class Spell(
     override fun replace(original: Spell) = copy(id = original.id)
 
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
+
+    override fun changeVisibility(isVisibleToPlayers: Boolean) =
+        copy(isVisibleToPlayers = isVisibleToPlayers)
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Spell.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Spell.kt
@@ -19,6 +19,7 @@ data class Spell(
     val castingNumber: Int,
     val effect: String,
     val lore: String,
+    override val isVisibleToPlayers: Boolean = true,
 ) : CompendiumItem<Spell>() {
     companion object {
         const val NAME_MAX_LENGTH = 50

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Talent.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Talent.kt
@@ -17,6 +17,7 @@ data class Talent(
     val tests: String = "", // TODO: Remove default value in 3.0
     val maxTimesTaken: String,
     val description: String,
+    override val isVisibleToPlayers: Boolean = true,
 ) : CompendiumItem<Talent>() {
     companion object {
         const val NAME_MAX_LENGTH = 50

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Talent.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Talent.kt
@@ -37,4 +37,7 @@ data class Talent(
     override fun replace(original: Talent) = copy(id = original.id)
 
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
+
+    override fun changeVisibility(isVisibleToPlayers: Boolean) =
+        copy(isVisibleToPlayers = isVisibleToPlayers)
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Trait.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Trait.kt
@@ -15,6 +15,7 @@ data class Trait(
     override val name: String,
     val specifications: Set<String>,
     val description: String,
+    override val isVisibleToPlayers: Boolean = true,
 ) : CompendiumItem<Trait>() {
     init {
         require(specifications.all { name.contains(it) })

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Trait.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Trait.kt
@@ -28,6 +28,9 @@ data class Trait(
 
     override fun duplicate() = copy(id = uuid4(), name = duplicateName())
 
+    override fun changeVisibility(isVisibleToPlayers: Boolean) =
+        copy(isVisibleToPlayers = isVisibleToPlayers)
+
     companion object {
         const val NAME_MAX_LENGTH = 50
         const val DESCRIPTION_MAX_LENGTH = 3000

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/BlessingImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/BlessingImport.kt
@@ -14,6 +14,7 @@ data class BlessingImport(
     val target: String,
     val duration: String,
     val effect: String,
+    val isVisibleToPlayers: Boolean = true,
 ) {
     init {
         require(name.isNotBlank()) { "Blessing name cannot be blank" }
@@ -31,6 +32,7 @@ data class BlessingImport(
         target = target,
         duration = duration,
         effect = effect,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     companion object {
@@ -40,6 +42,7 @@ data class BlessingImport(
             target = blessing.target,
             duration = blessing.duration,
             effect = blessing.effect,
+            isVisibleToPlayers = blessing.isVisibleToPlayers,
         )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/CareerImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/CareerImport.kt
@@ -18,6 +18,7 @@ data class CareerImport(
     val socialClass: SocialClass,
     val races: Set<Race>,
     val levels: List<Level>,
+    val isVisibleToPlayers: Boolean = true,
 ) {
     init {
         require(name.isNotBlank()) { "Career name cannot be blank" }
@@ -50,7 +51,8 @@ data class CareerImport(
                 talents = it.talents,
                 trappings = it.trappings,
             )
-        }
+        },
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     @Serializable
@@ -95,7 +97,8 @@ data class CareerImport(
                     talents = it.talents,
                     trappings = it.trappings,
                 )
-            }
+            },
+            isVisibleToPlayers = career.isVisibleToPlayers,
         )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/MiracleImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/MiracleImport.kt
@@ -15,6 +15,7 @@ data class MiracleImport(
     val duration: String,
     val effect: String,
     val cultName: String,
+    val isVisibleToPlayers: Boolean = true,
 ) {
     init {
         require(name.isNotBlank()) { "Miracle name cannot be blank" }
@@ -34,6 +35,7 @@ data class MiracleImport(
         duration = duration,
         effect = effect,
         cultName = cultName,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     companion object {
@@ -44,6 +46,7 @@ data class MiracleImport(
             duration = miracle.duration,
             effect = miracle.effect,
             cultName = miracle.cultName,
+            isVisibleToPlayers = miracle.isVisibleToPlayers,
         )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/SkillImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/SkillImport.kt
@@ -14,6 +14,7 @@ data class SkillImport(
     val description: String,
     val characteristic: Characteristic,
     val advanced: Boolean,
+    val isVisibleToPlayers: Boolean = true,
 ) {
     init {
         require(name.isNotBlank()) { "Skill name cannot be blank" }
@@ -27,6 +28,7 @@ data class SkillImport(
         description = description,
         characteristic = characteristic,
         advanced = advanced,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     companion object {
@@ -35,6 +37,7 @@ data class SkillImport(
             description = skill.description,
             characteristic = skill.characteristic,
             advanced = skill.advanced,
+            isVisibleToPlayers = skill.isVisibleToPlayers,
         )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/SpellImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/SpellImport.kt
@@ -16,6 +16,7 @@ data class SpellImport(
     val castingNumber: Int,
     val effect: String,
     val lore: String,
+    val isVisibleToPlayers: Boolean = true,
 ) {
     init {
         require(name.isNotBlank()) { "Spell name cannot be blank" }
@@ -37,6 +38,7 @@ data class SpellImport(
         castingNumber = castingNumber,
         effect = effect,
         lore = lore,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     companion object {
@@ -48,6 +50,7 @@ data class SpellImport(
             castingNumber = spell.castingNumber,
             effect = spell.effect,
             lore = spell.lore,
+            isVisibleToPlayers = spell.isVisibleToPlayers,
         )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/TalentImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/TalentImport.kt
@@ -13,6 +13,7 @@ data class TalentImport(
     val associatedTests: String,
     val maxTimesTaken: String,
     val description: String,
+    val isVisibleToPlayers: Boolean = true,
 ) {
     init {
         require(name.isNotBlank()) { "Talent name cannot be blank" }
@@ -26,6 +27,7 @@ data class TalentImport(
         name = name,
         maxTimesTaken = maxTimesTaken,
         description = description,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     companion object {
@@ -34,6 +36,7 @@ data class TalentImport(
             associatedTests = talent.tests,
             maxTimesTaken = talent.maxTimesTaken,
             description = talent.description,
+            isVisibleToPlayers = talent.isVisibleToPlayers,
         )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/TraitImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/TraitImport.kt
@@ -12,6 +12,7 @@ data class TraitImport(
     val name: String,
     val specifications: Set<String>,
     val description: String,
+    val isVisibleToPlayers: Boolean = true,
 ) {
     init {
         require(name.isNotBlank()) { "Trait name cannot be blank" }
@@ -30,6 +31,7 @@ data class TraitImport(
         name = name,
         specifications = specifications,
         description = description,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     companion object {
@@ -37,6 +39,7 @@ data class TraitImport(
             name = trait.name,
             specifications = trait.specifications,
             description = trait.description,
+            isVisibleToPlayers = trait.isVisibleToPlayers,
         )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/miracle/MiracleCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/miracle/MiracleCompendiumTab.kt
@@ -21,16 +21,18 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 @Composable
 fun MiracleCompendiumTab(partyId: PartyId, screenModel: MiracleCompendiumScreenModel, width: Dp) {
     var newMiracleDialogOpened by rememberSaveable { mutableStateOf(false) }
+    val navigator = LocalNavigator.currentOrThrow
 
     if (newMiracleDialogOpened) {
         MiracleDialog(
             miracle = null,
-            screenModel = screenModel,
             onDismissRequest = { newMiracleDialogOpened = false },
+            onSaveRequest = {
+                screenModel.createNew(it)
+                navigator.push(MiracleDetailScreen(partyId, it.id))
+            },
         )
     }
-
-    val navigator = LocalNavigator.currentOrThrow
 
     CompendiumTab(
         liveItems = screenModel.items,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/miracle/MiracleDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/miracle/MiracleDetailScreen.kt
@@ -33,7 +33,7 @@ class MiracleDetailScreen(
             MiracleDialog(
                 miracle = item,
                 onDismissRequest = onDismissRequest,
-                screenModel = screenModel,
+                onSaveRequest = screenModel::update,
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/miracle/MiracleDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/miracle/MiracleDialog.kt
@@ -23,8 +23,8 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 @Composable
 fun MiracleDialog(
     miracle: Miracle?,
-    screenModel: MiracleCompendiumScreenModel,
     onDismissRequest: () -> Unit,
+    onSaveRequest: suspend (Miracle) -> Unit,
 ) {
     val formData = MiracleFormData.fromItem(miracle)
     val strings = LocalStrings.current.miracles
@@ -32,7 +32,7 @@ fun MiracleDialog(
     CompendiumItemDialog(
         title = if (miracle == null) strings.titleNew else strings.titleEdit,
         formData = formData,
-        saver = if (miracle == null) screenModel::createNew else screenModel::update,
+        saver = onSaveRequest,
         onDismissRequest = onDismissRequest,
     ) { validate ->
         Column(
@@ -95,6 +95,7 @@ private data class MiracleFormData(
     val target: InputValue,
     val duration: InputValue,
     val effect: InputValue,
+    val isVisibleToPlayers: Boolean,
 ) : CompendiumItemFormData<Miracle> {
     companion object {
         @Composable
@@ -106,6 +107,7 @@ private data class MiracleFormData(
             target = inputValue(item?.target ?: ""),
             duration = inputValue(item?.duration ?: ""),
             effect = inputValue(item?.effect ?: ""),
+            isVisibleToPlayers = item?.isVisibleToPlayers ?: false,
         )
     }
 
@@ -117,6 +119,7 @@ private data class MiracleFormData(
         target = target.value,
         duration = duration.value,
         effect = effect.value,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     override fun isValid() =

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/skill/SkillCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/skill/SkillCompendiumTab.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.Dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cz.frantisekmasa.wfrp_master.common.compendium.CompendiumTab
+import cz.frantisekmasa.wfrp_master.common.compendium.VisibilityIcon
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.EmptyUI
@@ -21,16 +22,18 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 @Composable
 fun SkillCompendiumTab(partyId: PartyId, screenModel: SkillCompendiumScreenModel, width: Dp) {
     var newSkillDialogOpened by rememberSaveable { mutableStateOf(false) }
+    val navigator = LocalNavigator.currentOrThrow
 
     if (newSkillDialogOpened) {
         SkillDialog(
             skill = null,
-            screenModel = screenModel,
             onDismissRequest = { newSkillDialogOpened = false },
+            onSaveRequest = {
+                screenModel.createNew(it)
+                navigator.push(SkillDetailScreen(partyId, it.id))
+            }
         )
     }
-
-    val navigator = LocalNavigator.currentOrThrow
 
     CompendiumTab(
         liveItems = screenModel.items,
@@ -50,7 +53,8 @@ fun SkillCompendiumTab(partyId: PartyId, screenModel: SkillCompendiumScreenModel
     ) { skill ->
         ListItem(
             icon = { ItemIcon(skill.characteristic.getIcon()) },
-            text = { Text(skill.name) }
+            text = { Text(skill.name) },
+            trailing = { VisibilityIcon(skill) },
         )
         Divider()
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/skill/SkillDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/skill/SkillDetailScreen.kt
@@ -31,7 +31,7 @@ class SkillDetailScreen(
             SkillDialog(
                 skill = item,
                 onDismissRequest = onDismissRequest,
-                screenModel = screenModel,
+                onSaveRequest = screenModel::update,
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/skill/SkillDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/skill/SkillDialog.kt
@@ -34,7 +34,7 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 fun SkillDialog(
     skill: Skill?,
     onDismissRequest: () -> Unit,
-    screenModel: SkillCompendiumScreenModel,
+    onSaveRequest: suspend (Skill) -> Unit,
 ) {
     val formData = SkillFormData.fromItem(skill)
     val strings = LocalStrings.current.skills
@@ -42,7 +42,7 @@ fun SkillDialog(
     CompendiumItemDialog(
         title = if (skill == null) strings.titleNew else strings.titleEdit,
         formData = formData,
-        saver = if (skill == null) screenModel::createNew else screenModel::update,
+        saver = onSaveRequest,
         onDismissRequest = onDismissRequest,
     ) { validate ->
         Column(
@@ -96,6 +96,7 @@ private data class SkillFormData(
     val description: InputValue,
     val characteristic: MutableState<Characteristic>,
     val advanced: MutableState<Boolean>,
+    val isVisibleToPlayers: Boolean,
 ) : CompendiumItemFormData<Skill> {
     companion object {
         @Composable
@@ -105,6 +106,7 @@ private data class SkillFormData(
             description = inputValue(item?.description ?: ""),
             characteristic = rememberSaveable { mutableStateOf(item?.characteristic ?: Characteristic.AGILITY) },
             advanced = checkboxValue(item?.advanced ?: false),
+            isVisibleToPlayers = item?.isVisibleToPlayers ?: false,
         )
     }
 
@@ -113,7 +115,8 @@ private data class SkillFormData(
         name = name.value,
         description = description.value,
         characteristic = characteristic.value,
-        advanced = advanced.value
+        advanced = advanced.value,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     override fun isValid() =

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellCompendiumTab.kt
@@ -21,16 +21,18 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 @Composable
 fun SpellCompendiumTab(partyId: PartyId, screenModel: SpellCompendiumScreenModel, width: Dp) {
     var newSpellDialogOpened by rememberSaveable { mutableStateOf(false) }
+    val navigator = LocalNavigator.currentOrThrow
 
     if (newSpellDialogOpened) {
         SpellDialog(
             spell = null,
-            screenModel = screenModel,
             onDismissRequest = { newSpellDialogOpened = false },
+            onSaveRequest = {
+                screenModel.createNew(it)
+                navigator.push(SpellDetailScreen(partyId, it.id))
+            },
         )
     }
-
-    val navigator = LocalNavigator.currentOrThrow
 
     CompendiumTab(
         liveItems = screenModel.items,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellDetailScreen.kt
@@ -34,7 +34,7 @@ class SpellDetailScreen(
             SpellDialog(
                 spell = item,
                 onDismissRequest = onDismissRequest,
-                screenModel = screenModel,
+                onSaveRequest = screenModel::update,
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellDialog.kt
@@ -25,8 +25,8 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 @Composable
 fun SpellDialog(
     spell: Spell?,
-    screenModel: SpellCompendiumScreenModel,
     onDismissRequest: () -> Unit,
+    onSaveRequest: suspend (Spell) -> Unit,
 ) {
     val formData = SpellFormData.fromItem(spell)
 
@@ -35,7 +35,7 @@ fun SpellDialog(
     CompendiumItemDialog(
         title = if (spell == null) strings.titleAdd else strings.titleEdit,
         formData = formData,
-        saver = if (spell == null) screenModel::createNew else screenModel::update,
+        saver = onSaveRequest,
         onDismissRequest = onDismissRequest,
     ) { validate ->
         Column(
@@ -107,6 +107,7 @@ private data class SpellFormData(
     val duration: InputValue,
     val castingNumber: InputValue,
     val effect: InputValue,
+    val isVisibleToPlayers: Boolean,
 ) : CompendiumItemFormData<Spell> {
     companion object {
         @Composable
@@ -122,6 +123,7 @@ private data class SpellFormData(
                 Rules.NonNegativeInteger(),
             ),
             effect = inputValue(item?.effect ?: ""),
+            isVisibleToPlayers = item?.isVisibleToPlayers ?: false,
         )
     }
 
@@ -134,6 +136,7 @@ private data class SpellFormData(
         duration = duration.value,
         castingNumber = castingNumber.value.toInt(),
         effect = effect.value,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     override fun isValid() =

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentCompendiumTab.kt
@@ -21,16 +21,18 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 @Composable
 fun TalentCompendiumTab(partyId: PartyId, screenModel: TalentCompendiumScreenModel, width: Dp) {
     var newTalentDialogOpened by rememberSaveable { mutableStateOf(false) }
+    val navigator = LocalNavigator.currentOrThrow
 
     if (newTalentDialogOpened) {
         TalentDialog(
             talent = null,
-            screenModel = screenModel,
             onDismissRequest = { newTalentDialogOpened = false },
+            onSaveRequest = {
+                screenModel.createNew(it)
+                navigator.push(TalentDetailScreen(partyId, it.id))
+            }
         )
     }
-
-    val navigator = LocalNavigator.currentOrThrow
 
     CompendiumTab(
         liveItems = screenModel.items,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentDetailScreen.kt
@@ -31,7 +31,7 @@ class TalentDetailScreen(
             TalentDialog(
                 talent = item,
                 onDismissRequest = onDismissRequest,
-                screenModel = screenModel,
+                onSaveRequest = screenModel::update,
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentDialog.kt
@@ -24,7 +24,7 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 fun TalentDialog(
     talent: Talent?,
     onDismissRequest: () -> Unit,
-    screenModel: TalentCompendiumScreenModel
+    onSaveRequest: suspend (Talent) -> Unit,
 ) {
     val formData = TalentFormData.fromTalent(talent)
     val strings = LocalStrings.current.talents
@@ -33,7 +33,7 @@ fun TalentDialog(
         onDismissRequest = onDismissRequest,
         title = if (talent == null) strings.titleNew else strings.titleEdit,
         formData = formData,
-        saver = if (talent == null) screenModel::createNew else screenModel::update,
+        saver = onSaveRequest,
     ) { validate ->
         Column(
             verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -79,6 +79,7 @@ private data class TalentFormData(
     val tests: InputValue,
     val maxTimesTaken: InputValue,
     val description: InputValue,
+    val isVisibleToPlayers: Boolean,
 ) : CompendiumItemFormData<Talent> {
     companion object {
         @Composable
@@ -88,6 +89,7 @@ private data class TalentFormData(
             tests = inputValue(talent?.tests ?: ""),
             maxTimesTaken = inputValue(talent?.maxTimesTaken ?: ""),
             description = inputValue(talent?.description ?: ""),
+            isVisibleToPlayers = talent?.isVisibleToPlayers ?: false,
         )
     }
 
@@ -97,6 +99,7 @@ private data class TalentFormData(
         tests = tests.value.trim(),
         maxTimesTaken = maxTimesTaken.value,
         description = description.value,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     override fun isValid() = listOf(name, maxTimesTaken, description).all { it.isValid() }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trait/TraitCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trait/TraitCompendiumTab.kt
@@ -25,16 +25,18 @@ fun TraitCompendiumTab(
     width: Dp,
 ) {
     var newTraitDialogOpened by rememberSaveable { mutableStateOf(false) }
+    val navigator = LocalNavigator.currentOrThrow
 
     if (newTraitDialogOpened) {
         TraitDialog(
             trait = null,
-            screenModel = screenModel,
             onDismissRequest = { newTraitDialogOpened = false },
+            onSaveRequest = {
+                screenModel.createNew(it)
+                navigator.push(TraitDetailScreen(partyId, it.id))
+            }
         )
     }
-
-    val navigator = LocalNavigator.currentOrThrow
 
     CompendiumTab(
         liveItems = screenModel.items,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trait/TraitDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trait/TraitDetailScreen.kt
@@ -30,7 +30,7 @@ class TraitDetailScreen(
             TraitDialog(
                 trait = item,
                 onDismissRequest = onDismissRequest,
-                screenModel = screenModel,
+                onSaveRequest = screenModel::update,
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trait/TraitDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trait/TraitDialog.kt
@@ -24,7 +24,7 @@ import cz.frantisekmasa.wfrp_master.common.localization.LocalStrings
 fun TraitDialog(
     trait: Trait?,
     onDismissRequest: () -> Unit,
-    screenModel: TraitCompendiumScreenModel,
+    onSaveRequest: suspend (Trait) -> Unit,
 ) {
     val strings = LocalStrings.current.traits
     val formData = TraitFormData.fromTrait(trait)
@@ -33,7 +33,7 @@ fun TraitDialog(
         onDismissRequest = onDismissRequest,
         title = if (trait == null) strings.titleNew else strings.titleEdit,
         formData = formData,
-        saver = if (trait == null) screenModel::createNew else screenModel::update,
+        saver = onSaveRequest,
     ) { validate ->
         Column(
             verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -71,6 +71,7 @@ private data class TraitFormData(
     val name: InputValue,
     val specifications: InputValue,
     val description: InputValue,
+    val isVisibleToPlayers: Boolean,
 ) : CompendiumItemFormData<Trait> {
     companion object {
         @Composable
@@ -79,6 +80,7 @@ private data class TraitFormData(
             name = inputValue(trait?.name ?: "", Rules.NotBlank()),
             specifications = inputValue(trait?.specifications?.joinToString(",") ?: ""),
             description = inputValue(trait?.description ?: ""),
+            isVisibleToPlayers = trait?.isVisibleToPlayers ?: false,
         )
     }
 
@@ -93,6 +95,7 @@ private data class TraitFormData(
             .map { it.trim() }
             .toSet(),
         description = description.value,
+        isVisibleToPlayers = isVisibleToPlayers,
     )
 
     override fun isValid() = listOf(name, specifications, description).all { it.isValid() }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/auth/User.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/auth/User.kt
@@ -6,6 +6,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class User(
     @SerialName("localId")
-    val id: String,
+    val id: UserId,
     val email: String?,
 )

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/auth/UserId.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/auth/UserId.kt
@@ -2,9 +2,17 @@ package cz.frantisekmasa.wfrp_master.common.core.auth
 
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelable
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelize
+import kotlinx.serialization.Serializable
 
 @Parcelize
-data class UserId internal constructor(private val value: String) : Parcelable {
+@JvmInline
+@Serializable
+value class UserId internal constructor(private val value: String) : Parcelable {
+
+    init {
+        require(value.isNotBlank()) { "UserId cannot be blank" }
+    }
+
     companion object {
         fun fromString(userId: String): UserId = UserId(userId)
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/auth/UserProvider.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/auth/UserProvider.kt
@@ -1,0 +1,5 @@
+package cz.frantisekmasa.wfrp_master.common.core.auth
+
+interface UserProvider {
+    val userId: UserId?
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/Character.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/Character.kt
@@ -3,6 +3,7 @@ package cz.frantisekmasa.wfrp_master.common.core.domain.character
 import androidx.compose.runtime.Immutable
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
 import cz.frantisekmasa.wfrp_master.common.core.domain.Ambitions
 import cz.frantisekmasa.wfrp_master.common.core.domain.Money
@@ -26,7 +27,7 @@ data class Character(
     val type: CharacterType = CharacterType.PLAYER_CHARACTER,
     val name: String,
     val publicName: String? = null,
-    val userId: String?,
+    val userId: UserId?,
     val career: String,
     val compendiumCareer: CompendiumCareer? = null,
     val socialClass: String,
@@ -70,7 +71,7 @@ data class Character(
         require(publicName == null || type == CharacterType.NPC) {
             "Only NPC can have a public name"
         }
-        require(listOf(name, userId).all { it?.isNotBlank() ?: true })
+        require(name.isNotBlank())
         require(name.length <= NAME_MAX_LENGTH) { "Character name is too long" }
         require(career.length <= CAREER_MAX_LENGTH) { "Career is too long" }
         require(socialClass.length <= SOCIAL_CLASS_MAX_LENGTH) { "Social class is too long" }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/Party.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/Party.kt
@@ -20,8 +20,8 @@ import kotlinx.serialization.Serializable
 data class Party(
     val id: PartyId,
     val name: String,
-    val gameMasterId: String?, // Remove support for single-player parties in 1.14
-    private val users: Set<String>,
+    val gameMasterId: UserId?, // Remove support for single-player parties in 1.14
+    private val users: Set<UserId>,
     private val archived: Boolean = false,
     val ambitions: Ambitions = Ambitions("", ""),
     val time: DateTime = DateTime(
@@ -44,9 +44,7 @@ data class Party(
 
     val playersCount: Int get() = users.size - 1
 
-    val players: List<UserId> get() =
-        users.filter { it != gameMasterId }
-            .map(UserId::fromString)
+    val players: List<UserId> get() = users.filter { it != gameMasterId }
 
     fun updateAmbitions(ambitions: Ambitions) = copy(ambitions = ambitions)
 
@@ -75,8 +73,8 @@ data class Party(
     fun changeTime(time: DateTime) = copy(time = time)
 
     fun leave(userId: UserId) = copy(
-        users = users.filter { it != userId.toString() }.toSet()
+        users = users.filter { it != userId }.toSet()
     )
 
-    fun isMember(userId: UserId): Boolean = users.contains(userId.toString())
+    fun isMember(userId: UserId): Boolean = userId in users
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/PartyRepository.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/party/PartyRepository.kt
@@ -1,6 +1,7 @@
 package cz.frantisekmasa.wfrp_master.common.core.domain.party
 
 import arrow.core.Either
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.connectivity.CouldNotConnectToBackend
 import kotlinx.coroutines.flow.Flow
 
@@ -26,7 +27,7 @@ interface PartyRepository {
     /**
      * Creates RecyclerView Adapter with parties that user has access to
      */
-    fun forUserLive(userId: String): Flow<List<Party>>
+    fun forUserLive(userId: UserId): Flow<List<Party>>
 
-    suspend fun forUser(userId: String): List<Party>
+    suspend fun forUser(userId: UserId): List<Party>
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/firebase/repositories/FirestorePartyRepository.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/firebase/repositories/FirestorePartyRepository.kt
@@ -2,6 +2,7 @@ package cz.frantisekmasa.wfrp_master.common.core.firebase.repositories
 
 import arrow.core.left
 import arrow.core.right
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.connectivity.CouldNotConnectToBackend
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.Party
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
@@ -77,15 +78,15 @@ class FirestorePartyRepository(
                 )
             }
 
-    override fun forUserLive(userId: String) = queryForUser(userId).documents(mapper)
+    override fun forUserLive(userId: UserId) = queryForUser(userId).documents(mapper)
 
-    override suspend fun forUser(userId: String) =
+    override suspend fun forUser(userId: UserId) =
         queryForUser(userId)
             .get()
             .documents
             .map { mapper.fromDocumentSnapshot(it) }
 
-    private fun queryForUser(userId: String) = parties
-        .whereArrayContains("users", userId)
+    private fun queryForUser(userId: UserId) = parties
+        .whereArrayContains("users", userId.toString())
         .whereEqualTo("archived", false)
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/logging/Reporter.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/logging/Reporter.kt
@@ -1,7 +1,9 @@
 package cz.frantisekmasa.wfrp_master.common.core.logging
 
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
+
 expect object Reporter {
-    fun setUserId(id: String)
+    fun setUserId(id: UserId)
 
     fun log(message: String)
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/CombatantItem.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/CombatantItem.kt
@@ -1,6 +1,7 @@
 package cz.frantisekmasa.wfrp_master.common.encounters
 
 import androidx.compose.runtime.Immutable
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.Stats
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CurrentConditions
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
@@ -26,7 +27,7 @@ sealed class CombatantItem {
         override val combatant: Combatant.Character,
     ) : CombatantItem() {
 
-        val userId: String?
+        val userId: UserId?
             get() = character.userId
 
         val avatarUrl: String?

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/gameMaster/GameMasterScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/gameMaster/GameMasterScreenModel.kt
@@ -32,7 +32,7 @@ class GameMasterScreenModel(
         party.filterNotNull().combineTransform(playerCharacters) { party, characters ->
             val players = characters.map { Player.ExistingCharacter(it) }
             val usersWithoutCharacter = party.players
-                .filter { userId -> players.none { it.character.userId == userId.toString() } }
+                .filter { userId -> players.none { it.character.userId == userId } }
                 .map { Player.UserWithoutCharacter(it.toString()) }
 
             emit(players + usersWithoutCharacter)

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/invitation/InvitationScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/invitation/InvitationScreenModel.kt
@@ -1,6 +1,7 @@
 package cz.frantisekmasa.wfrp_master.common.invitation
 
 import cafe.adriel.voyager.core.model.ScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.Invitation
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.Party
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyRepository
@@ -21,11 +22,11 @@ class InvitationScreenModel(
     private val parties: PartyRepository,
 ) : ScreenModel {
 
-    suspend fun acceptInvitation(userId: String, invitation: Invitation): InvitationProcessingResult {
+    suspend fun acceptInvitation(userId: UserId, invitation: Invitation): InvitationProcessingResult {
         return withContext(Dispatchers.IO) { invitationProcessor.accept(userId, invitation) }
     }
 
-    fun userParties(userId: String): Flow<List<Party>> {
+    fun userParties(userId: UserId): Flow<List<Party>> {
         return parties.forUserLive(userId)
     }
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/invitation/domain/FirestoreInvitationProcessor.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/invitation/domain/FirestoreInvitationProcessor.kt
@@ -14,13 +14,13 @@ class FirestoreInvitationProcessor(
     private val parties: PartyRepository
 ) : InvitationProcessor {
 
-    override suspend fun accept(userId: String, invitation: Invitation): InvitationProcessingResult {
+    override suspend fun accept(userId: UserId, invitation: Invitation): InvitationProcessingResult {
         if (isAlreadyInParty(userId, invitation.partyId)) {
             return InvitationProcessingResult.AlreadyInParty
         }
 
         firestore.collection("users")
-            .document(userId)
+            .document(userId.toString())
             .set(
                 mapOf(
                     "invitations" to arrayUnion(
@@ -40,9 +40,9 @@ class FirestoreInvitationProcessor(
         return InvitationProcessingResult.Success
     }
 
-    private suspend fun isAlreadyInParty(userId: String, partyId: PartyId): Boolean {
+    private suspend fun isAlreadyInParty(userId: UserId, partyId: PartyId): Boolean {
         return try {
-            parties.get(partyId).isMember(UserId.fromString(userId))
+            parties.get(partyId).isMember(userId)
         } catch (e: PartyNotFound) {
             false
         }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/invitation/domain/InvitationProcessor.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/invitation/domain/InvitationProcessor.kt
@@ -1,12 +1,13 @@
 package cz.frantisekmasa.wfrp_master.common.invitation.domain
 
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.Invitation
 
 interface InvitationProcessor {
     /**
      * Gives user access to the party
      */
-    suspend fun accept(userId: String, invitation: Invitation): InvitationProcessingResult
+    suspend fun accept(userId: UserId, invitation: Invitation): InvitationProcessingResult
 }
 
 sealed interface InvitationProcessingResult {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -539,6 +539,8 @@ data class CompendiumStrings(
     val titleImportCompendium: String = "Import Compendium",
     val titleExportCompendium: String = "Export Compendium",
     val titleImportDialog: String = "Importing Rulebook…",
+    val visibleToPlayersTrue: String = "Visible to Players",
+    val visibleToPlayersFalse: String = "Invisible to Players",
 )
 
 @Immutable

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/partyList/LeavePartyDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/partyList/LeavePartyDialog.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import cz.frantisekmasa.wfrp_master.common.core.auth.LocalUser
-import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.Party
 import cz.frantisekmasa.wfrp_master.common.core.shared.IO
 import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.AlertDialog
@@ -42,7 +41,7 @@ fun LeavePartyDialog(party: Party, screenModel: PartyListScreenModel, onDismissR
         },
         confirmButton = {
             val coroutineScope = rememberCoroutineScope()
-            val userId = UserId.fromString(LocalUser.current.id)
+            val userId = LocalUser.current.id
 
             TextButton(
                 enabled = !removing,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/partyList/PartyListScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/partyList/PartyListScreenModel.kt
@@ -13,7 +13,7 @@ class PartyListScreenModel(
     private val parties: PartyRepository
 ) : ScreenModel {
 
-    fun liveForUser(userId: String): Flow<List<Party>> {
+    fun liveForUser(userId: UserId): Flow<List<Party>> {
         return parties.forUserLive(userId)
     }
 
@@ -24,7 +24,7 @@ class PartyListScreenModel(
     /**
      * @throws CouldNotConnectToBackend
      */
-    suspend fun createParty(partyName: String, gameMasterId: String): PartyId {
+    suspend fun createParty(partyName: String, gameMasterId: UserId): PartyId {
         val partyId = PartyId.generate()
         val party = Party(
             id = partyId,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/settings/SettingsScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/settings/SettingsScreenModel.kt
@@ -1,6 +1,7 @@
 package cz.frantisekmasa.wfrp_master.common.settings
 
 import cafe.adriel.voyager.core.model.ScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyRepository
 import cz.frantisekmasa.wfrp_master.common.core.shared.SettingsKey
 import cz.frantisekmasa.wfrp_master.common.core.shared.SettingsStorage
@@ -17,7 +18,8 @@ class SettingsScreenModel(
     val darkMode: Flow<Boolean?> by lazy { getPreference(AppSettings.DARK_MODE) }
     val soundEnabled: Flow<Boolean?> by lazy { getPreference(AppSettings.SOUND_ENABLED) }
     val lastSeenVersion: Flow<String?> by lazy { storage.watch(AppSettings.LAST_SEEN_VERSION) }
-    suspend fun getPartyNames(userId: String): List<String> {
+
+    suspend fun getPartyNames(userId: UserId): List<String> {
         return parties.forUser(userId).map { it.name }
     }
 

--- a/common/src/commonTest/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/CharacterTest.kt
+++ b/common/src/commonTest/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/CharacterTest.kt
@@ -1,6 +1,7 @@
 package cz.frantisekmasa.wfrp_master.common.core.domain.character
 
 import com.benasher44.uuid.uuid4
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.Money
 import cz.frantisekmasa.wfrp_master.common.core.domain.Stats
 import kotlin.test.Test
@@ -11,7 +12,7 @@ class CharacterTest {
     private fun character() = Character(
         id = uuid4().toString(),
         name = "Bilbo",
-        userId = "123",
+        userId = UserId("123"),
         career = "Writer",
         socialClass = "Noble",
         status = SocialStatus(SocialStatus.Tier.GOLD, 2),

--- a/common/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/common/auth/AuthenticationManager.kt
+++ b/common/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/common/auth/AuthenticationManager.kt
@@ -30,7 +30,7 @@ class AuthenticationManager(
         val status = statusFlow.value
 
         if (status is AuthenticationStatus.Authenticated) {
-            return UserId(status.user.id)
+            return status.user.id
         }
 
         return null

--- a/common/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/common/auth/AuthenticationManager.kt
+++ b/common/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/common/auth/AuthenticationManager.kt
@@ -2,6 +2,8 @@ package cz.frantisekmasa.wfrp_master.common.auth
 
 import cz.frantisekmasa.wfrp_master.common.FirebaseTokenHolder
 import cz.frantisekmasa.wfrp_master.common.core.auth.User
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserProvider
 import cz.frantisekmasa.wfrp_master.common.core.shared.SettingsStorage
 import cz.frantisekmasa.wfrp_master.common.core.shared.edit
 import cz.frantisekmasa.wfrp_master.common.core.shared.stringKey
@@ -21,8 +23,18 @@ class AuthenticationManager(
     private val http: HttpClient,
     private val tokenHolder: FirebaseTokenHolder,
     private val settings: SettingsStorage,
-) {
+) : UserProvider {
     private val statusFlow = MutableStateFlow<AuthenticationStatus?>(null)
+
+    override val userId: UserId? get() {
+        val status = statusFlow.value
+
+        if (status is AuthenticationStatus.Authenticated) {
+            return UserId(status.user.id)
+        }
+
+        return null
+    }
 
     val status: Flow<AuthenticationStatus?> get() = statusFlow
 

--- a/common/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/logging/Reporter.kt
+++ b/common/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/logging/Reporter.kt
@@ -1,8 +1,10 @@
 package cz.frantisekmasa.wfrp_master.common.core.logging
 
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
+
 // TODO: Add Sentry?
 actual object Reporter {
-    actual fun setUserId(id: String) {
+    actual fun setUserId(id: UserId) {
     }
 
     actual fun log(message: String) {

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -2,7 +2,7 @@ rules_version = '2';
 
 service cloud.firestore {
     match /databases/{database}/documents {
-   
+
         match /parties/{party=**} {
             allow read: if request.auth.uid != null
                         && request.auth.uid in resource.data.users;
@@ -23,12 +23,20 @@ service cloud.firestore {
                 allow delete: if isGameMaster();
 
                 function isValidSkill(skill) {
-                    return skill.keys().toSet() == ["id", "name", "description", "advanced", "characteristic"].toSet()
+                    return [
+                       "id",
+                       "name",
+                       "description",
+                       "advanced",
+                       "characteristic",
+                       "isVisibleToPlayers"
+                   ].hasAll(skill.keys())
                         && skill.id is string && skill.id == skillId && isValidUuid(skill.id)
                         && skill.name is string && isNotBlank(skill.name) && skill.name.size() <= 50
                         && skill.description is string && skill.description.size() <= 2500
                         && skill.advanced is bool
-                        && skill.characteristic in validCharacteristics();
+                        && skill.characteristic in validCharacteristics()
+                        && (! ("isVisibleToPlayers" in skill) || skill.isVisibleToPlayers is bool);
                 }
             }
 
@@ -39,12 +47,21 @@ service cloud.firestore {
                 allow delete: if isGameMaster();
 
                 function isValidTalent(talent) {
-                    return ["id", "name", "maxTimesTaken", "description", "tests"].hasAll(talent.keys())
+                    return [
+                       "id",
+                       "name",
+                       "maxTimesTaken",
+                       "description",
+                       "tests",
+                       "isVisibleToPlayers"
+                   ].hasAll(talent.keys())
                         && talent.id is string && talent.id == talentId && isValidUuid(talent.id)
                         && talent.name is string && isNotBlank(talent.name) && talent.name.size() <= 50
                         && talent.maxTimesTaken is string && talent.name.size() <= 100
                         && talent.description is string && talent.description.size() <= 1500
-                        && (! ("tests" in talent) || (talent.tests is string && talent.tests.size() <= 200));
+                        && (! ("tests" in talent) || (talent.tests is string && talent.tests.size() <= 200))
+                        && (! ("isVisibleToPlayers" in talent) || talent.isVisibleToPlayers is bool);
+
                 }
             }
 
@@ -55,7 +72,17 @@ service cloud.firestore {
                 allow delete: if isGameMaster();
 
                 function isValidSpell(spell) {
-                    return spell.keys().toSet() == ["id", "name", "range", "target", "duration", "castingNumber", "effect", "lore"].toSet()
+                    return [
+                       "id",
+                       "name",
+                       "range",
+                       "target",
+                       "duration",
+                       "castingNumber",
+                       "effect",
+                       "lore",
+                       "isVisibleToPlayers"
+                    ].hasAll(spell.keys())
                         && spell.id is string && spell.id == spellId && isValidUuid(spell.id)
                         && spell.name is string && isNotBlank(spell.name) && spell.name.size() <= 50
                         && spell.range is string && spell.range.size() <= 50
@@ -63,7 +90,8 @@ service cloud.firestore {
                         && spell.duration is string && spell.duration.size() <= 50
                         && spell.effect is string && spell.effect.size() <= 1000
                         && spell.castingNumber is int && spell.castingNumber >= 0 && spell.castingNumber <= 99
-                        && spell.lore is string && spell.lore.size() <= 50;
+                        && spell.lore is string && spell.lore.size() <= 50
+                        && (! ("isVisibleToPlayers" in spell) || spell.isVisibleToPlayers is bool);
                 }
             }
 
@@ -74,13 +102,22 @@ service cloud.firestore {
                 allow delete: if isGameMaster();
 
                 function isValidBlessing(blessing) {
-                    return blessing.keys().toSet() == ["id", "name", "range", "target", "duration", "effect"].toSet()
+                    return [
+                       "id",
+                       "name",
+                       "range",
+                       "target",
+                       "duration",
+                       "effect",
+                       "isVisibleToPlayers"
+                   ].hasAll(blessing.keys())
                         && blessing.id is string && blessing.id == blessingId && isValidUuid(blessing.id)
                         && blessing.name is string && isNotBlank(blessing.name) && blessing.name.size() <= 50
                         && blessing.range is string && blessing.range.size() <= 50
                         && blessing.target is string && blessing.target.size() <= 50
                         && blessing.duration is string && blessing.duration.size() <= 50
-                        && blessing.effect is string && blessing.effect.size() <= 1000;
+                        && blessing.effect is string && blessing.effect.size() <= 1000
+                        && (! ("isVisibleToPlayers" in blessing) || blessing.isVisibleToPlayers is bool);
                 }
             }
 
@@ -91,14 +128,24 @@ service cloud.firestore {
                 allow delete: if isGameMaster();
 
                 function isValidMiracle(miracle) {
-                    return miracle.keys().toSet() == ["id", "name", "range", "target", "duration", "effect", "cultName"].toSet()
+                    return [
+                       "id",
+                       "name",
+                       "range",
+                       "target",
+                       "duration",
+                       "effect",
+                       "cultName",
+                       "isVisibleToPlayers"
+                   ].hasAll(miracle.keys())
                         && miracle.id is string && miracle.id == miracleId && isValidUuid(miracle.id)
                         && miracle.name is string && isNotBlank(miracle.name) && miracle.name.size() <= 50
                         && miracle.range is string && miracle.range.size() <= 50
                         && miracle.target is string && miracle.target.size() <= 50
                         && miracle.duration is string && miracle.duration.size() <= 50
                         && miracle.effect is string && miracle.effect.size() <= 1000
-                        && miracle.cultName is string && miracle.cultName.size() <= 50;
+                        && miracle.cultName is string && miracle.cultName.size() <= 50
+                        && (! ("isVisibleToPlayers" in miracle) || miracle.isVisibleToPlayers is bool);
                 }
             }
 
@@ -109,10 +156,17 @@ service cloud.firestore {
                 allow delete: if isGameMaster();
 
                 function isValidTrait(trait) {
-                    return trait.keys().toSet() == ["id", "name", "specifications", "description"].toSet()
-                           && trait.id is string && trait.id == traitId && isValidUuid(trait.id)
-                           && trait.name is string && isNotBlank(trait.name) && trait.name.size() <= 50
-                           && trait.description is string && trait.description.size() <= 3000;
+                    return [
+                        "id",
+                        "name",
+                        "specifications",
+                        "description",
+                        "isVisibleToPlayers"
+                    ].hasAll(trait.keys())
+                        && trait.id is string && trait.id == traitId && isValidUuid(trait.id)
+                        && trait.name is string && isNotBlank(trait.name) && trait.name.size() <= 50
+                        && trait.description is string && trait.description.size() <= 3000
+                        && (! ("isVisibleToPlayers" in trait) || trait.isVisibleToPlayers is bool);
                 }
             }
 
@@ -124,7 +178,15 @@ service cloud.firestore {
                 allow delete: if isGameMaster();
 
                 function isValidCareer(career) {
-                    return career.keys().toSet() == ["id", "name", "description", "socialClass", "races", "levels"].toSet()
+                    return [
+                        "id",
+                        "name",
+                        "description",
+                        "socialClass",
+                        "races",
+                        "levels",
+                        "isVisibleToPlayers"
+                    ].hasAll(career.keys())
                         && career.id is string && career.id == careerId && isValidUuid(career.id)
                         && career.name is string && isNotBlank(career.name) && career.name.size() <= 50
                         && career.description is string && career.description.size() <= 3000
@@ -132,7 +194,8 @@ service cloud.firestore {
                         && career.races is list
                             && career.races.toSet().size() == career.races.size() // There are no duplicates
                             && validRaces().hasAll(career.races)
-                        && career.levels is list;
+                        && career.levels is list
+                        && (! ("isVisibleToPlayers" in career) || career.isVisibleToPlayers is bool);
                 }
 
                 function isValidSocialClass(socialClass) {
@@ -713,7 +776,7 @@ service cloud.firestore {
                 return request.auth != null
                     && (request.auth.uid == party.gameMasterId || (request.auth.uid in party.users && party.gameMasterId == null));
             }
-        
+
             function hasAccessToParty() {
                 return request.auth != null
                     && request.auth.uid in get(/databases/$(database)/documents/parties/$(partyId)).data.users


### PR DESCRIPTION
This change allows GMs to restrict the visibility of certain Compendium items (such as spells or traits).
These items will not be visible in compendium item choosers for Players.

There are several use cases for this:

- I would like to introduce Trapping Compendium in the future and GM may want to use it to track special items, that Players should not see
- New Traits and Spells are added for several NPCs in various adventure books. These should IMO not be available
to Players as they may hint at spoilers for the adventure.  