### PR TITLE
Fix import of Spell effects

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/parsers/SpellParser.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/parsers/SpellParser.kt
@@ -90,7 +90,7 @@ class SpellParser(
                         listOf(
                             listOf(Token.NormalPart(effectStart)),
                             stream.consumeUntil { it is Token.Heading },
-                        ).filterIsInstance<Token.ParagraphToken>()
+                        ).flatten().filterIsInstance<Token.ParagraphToken>()
                     ),
                     lore = lore,
                 )


### PR DESCRIPTION
Right now, Spell import refactoring in cbbed205d93156e3db626d9de8233f0a1c61ba1f broke import of Spell effect.

This fixes it.