### PR TITLE
Show visibility icons for all compendium items

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerCompendiumTab.kt
@@ -13,6 +13,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.benasher44.uuid.uuid4
 import cz.frantisekmasa.wfrp_master.common.compendium.CompendiumTab
+import cz.frantisekmasa.wfrp_master.common.compendium.VisibilityIcon
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Career
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
@@ -67,7 +68,8 @@ fun CareerCompendiumTab(partyId: PartyId, screenModel: CareerCompendiumScreenMod
     ) { career ->
         ListItem(
             icon = { ItemIcon(Resources.Drawable.Career) },
-            text = { Text(career.name) }
+            text = { Text(career.name) },
+            trailing = { VisibilityIcon(career) },
         )
         Divider()
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/miracle/MiracleCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/miracle/MiracleCompendiumTab.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.Dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cz.frantisekmasa.wfrp_master.common.compendium.CompendiumTab
+import cz.frantisekmasa.wfrp_master.common.compendium.VisibilityIcon
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.EmptyUI
@@ -53,7 +54,8 @@ fun MiracleCompendiumTab(partyId: PartyId, screenModel: MiracleCompendiumScreenM
     ) { miracle ->
         ListItem(
             icon = { ItemIcon(Resources.Drawable.Miracle) },
-            text = { Text(miracle.name) }
+            text = { Text(miracle.name) },
+            trailing = { VisibilityIcon(miracle) },
         )
         Divider()
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellCompendiumTab.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.Dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cz.frantisekmasa.wfrp_master.common.compendium.CompendiumTab
+import cz.frantisekmasa.wfrp_master.common.compendium.VisibilityIcon
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.EmptyUI
@@ -52,7 +53,8 @@ fun SpellCompendiumTab(partyId: PartyId, screenModel: SpellCompendiumScreenModel
     ) { spell ->
         ListItem(
             icon = { ItemIcon(Resources.Drawable.Spell) },
-            text = { Text(spell.name) }
+            text = { Text(spell.name) },
+            trailing = { VisibilityIcon(spell) },
         )
         Divider()
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/talent/TalentCompendiumTab.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.Dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cz.frantisekmasa.wfrp_master.common.compendium.CompendiumTab
+import cz.frantisekmasa.wfrp_master.common.compendium.VisibilityIcon
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.EmptyUI
@@ -52,7 +53,8 @@ fun TalentCompendiumTab(partyId: PartyId, screenModel: TalentCompendiumScreenMod
     ) { talent ->
         ListItem(
             icon = { ItemIcon(Resources.Drawable.Talent) },
-            text = { Text(talent.name) }
+            text = { Text(talent.name) },
+            trailing = { VisibilityIcon(talent) },
         )
         Divider()
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trait/TraitCompendiumTab.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trait/TraitCompendiumTab.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.Dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cz.frantisekmasa.wfrp_master.common.compendium.CompendiumTab
+import cz.frantisekmasa.wfrp_master.common.compendium.VisibilityIcon
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.EmptyUI
@@ -56,7 +57,8 @@ fun TraitCompendiumTab(
     ) { trait ->
         ListItem(
             icon = { ItemIcon(Resources.Drawable.Trait) },
-            text = { Text(trait.name) }
+            text = { Text(trait.name) },
+            trailing = { VisibilityIcon(trait) },
         )
         Divider()
     }


### PR DESCRIPTION
This was an oversight in https://github.com/fmasa/wfrp-master/pull/112