### PR TITLE
Spell Lores

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/spells/dialog/SpellDetail.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/spells/dialog/SpellDetail.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.markdown.Markdown
 import com.halilibo.richtext.ui.RichText
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.SpellLore
+import cz.frantisekmasa.wfrp_master.common.core.domain.localizedName
 import cz.frantisekmasa.wfrp_master.common.core.domain.spells.Spell
 import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.CloseButton
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
@@ -46,6 +48,7 @@ fun SpellDetail(
                 effectiveCastingNumber = spell.effectiveCastingNumber,
                 range = spell.range,
                 target = spell.target,
+                lore = spell.lore,
                 duration = spell.duration,
                 effect = spell.effect,
             )
@@ -59,6 +62,7 @@ fun SpellDetailBody(
     effectiveCastingNumber: Int,
     range: String,
     target: String,
+    lore: SpellLore?,
     duration: String,
     effect: String,
 ) {
@@ -85,6 +89,10 @@ fun SpellDetailBody(
         SingleLineTextValue(strings.labelTarget, target)
 
         SingleLineTextValue(strings.labelDuration, duration)
+
+        if (lore != null) {
+            SingleLineTextValue(strings.labelLore, lore.localizedName)
+        }
 
         RichText(Modifier.padding(top = 8.dp)) {
             Markdown(effect)

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Spell.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/Spell.kt
@@ -5,6 +5,7 @@ import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelize
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Parcelize
@@ -18,7 +19,11 @@ data class Spell(
     val duration: String,
     val castingNumber: Int,
     val effect: String,
-    val lore: String,
+    @SerialName("lore")
+    @Deprecated("Remove this in favor of [lore] enum")
+    val customLore: String,
+    @SerialName("loreType")
+    val lore: SpellLore? = null,
     override val isVisibleToPlayers: Boolean = true,
 ) : CompendiumItem<Spell>() {
     companion object {
@@ -38,7 +43,7 @@ data class Spell(
         require(target.length <= TARGET_MAX_LENGTH) { "Target must be shorter than $TARGET_MAX_LENGTH" }
         require(duration.length <= DURATION_MAX_LENGTH) { "Duration must be shorter than $DURATION_MAX_LENGTH" }
         require(effect.length <= EFFECT_MAX_LENGTH) { "Effect must be shorter than $EFFECT_MAX_LENGTH" }
-        require(lore.length <= LORE_MAX_LENGTH) { "LORE must be shorter than $LORE_MAX_LENGTH" }
+        require(customLore.length <= LORE_MAX_LENGTH) { "LORE must be shorter than $LORE_MAX_LENGTH" }
     }
 
     override fun replace(original: Spell) = copy(id = original.id)

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/SpellLore.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/SpellLore.kt
@@ -1,0 +1,26 @@
+package cz.frantisekmasa.wfrp_master.common.compendium.domain
+
+import cz.frantisekmasa.wfrp_master.common.core.domain.NamedEnum
+import cz.frantisekmasa.wfrp_master.common.localization.Strings
+
+enum class SpellLore(
+    override val nameResolver: (strings: Strings) -> String,
+    val wind: String?,
+) : NamedEnum {
+    BEASTS({ it.spells.lores.beasts }, "Ghur"),
+    DEATH({ it.spells.lores.death }, "Shyish"),
+    FIRE({ it.spells.lores.fire }, "Aqshy"),
+    HEAVENS({ it.spells.lores.heavens }, "Heavens"),
+    METAL({ it.spells.lores.metal }, "Azyr"),
+    LIFE({ it.spells.lores.life }, "Chamon"),
+    LIGHT({ it.spells.lores.light }, "Ghyran"),
+    SHADOWS({ it.spells.lores.shadows }, "Ulgu"),
+    HEDGECRAFT({ it.spells.lores.hedgecraft }, null),
+    WITCHCRAFT({ it.spells.lores.witchcraft }, null),
+    DAEMONOLOGY({ it.spells.lores.daemonology }, "Dhar"),
+    NECROMANCY({ it.spells.lores.necromancy }, "Dhar"),
+    NURGLE({ it.spells.lores.nurgle }, "Dhar"),
+    SLAANESH({ it.spells.lores.slaanesh }, "Dhar"),
+    TZEENTCH({ it.spells.lores.tzeentch }, "Dhar"),
+    PETTY({ it.spells.lores.petty }, null),
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/books/CoreRulebook.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/books/CoreRulebook.kt
@@ -5,6 +5,7 @@ import cz.frantisekmasa.wfrp_master.common.compendium.domain.Career
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Miracle
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Skill
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Spell
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.SpellLore
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Talent
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Trait
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.parsers.BlessingParser
@@ -81,8 +82,8 @@ object CoreRulebook :
     override fun importSpells(document: Document): List<Spell> {
         return SpellParser(
             specialLores = mapOf(
-                "Petty Spells" to "Petty Spells",
-                "Arcane Spells" to "Arcane Spells",
+                "Petty Spells" to setOf(SpellLore.PETTY),
+                "Arcane Spells" to SpellLore.values().toSet() - SpellLore.PETTY,
             ),
         ).import(document, this, sequenceOf(240..257))
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/books/EnemyInShadowsCompanion.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/books/EnemyInShadowsCompanion.kt
@@ -1,6 +1,7 @@
 package cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.books
 
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Spell
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.SpellLore
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.parsers.Document
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.parsers.SpellParser
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.parsers.TextPosition
@@ -17,7 +18,11 @@ object EnemyInShadowsCompanion : Book, SpellSource {
     override fun importSpells(document: Document): List<Spell> {
         return SpellParser(
             specialLores = mapOf(
-                "Chaos Arcane Spells" to "Chaos Arcane Spells",
+                "Chaos Arcane Spells" to setOf(
+                    SpellLore.NURGLE,
+                    SpellLore.SLAANESH,
+                    SpellLore.TZEENTCH,
+                ),
             ),
             ignoredSpellLikeHeadings = setOf("Lore Attribute"),
         ).import(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/books/WindsOfMagic.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/domain/importer/books/WindsOfMagic.kt
@@ -2,6 +2,7 @@ package cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.books
 
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Career
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Spell
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.SpellLore
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.parsers.CareerParser
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.parsers.Document
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.parsers.SpellParser
@@ -32,7 +33,7 @@ object WindsOfMagic : Book, CareerSource, SpellSource {
     override fun importSpells(document: Document): List<Spell> {
         return SpellParser(
             specialLores = mapOf(
-                "New Arcane Spells" to "Arcane Spells",
+                "New Arcane Spells" to SpellLore.values().toSet() - SpellLore.PETTY,
             ),
             isEnd = {
                 (

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/SpellImport.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/import/SpellImport.kt
@@ -3,6 +3,7 @@ package cz.frantisekmasa.wfrp_master.common.compendium.import
 import androidx.compose.runtime.Immutable
 import com.benasher44.uuid.uuid4
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Spell
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.SpellLore
 import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
 import kotlinx.serialization.Serializable
 
@@ -15,7 +16,8 @@ data class SpellImport(
     val duration: String,
     val castingNumber: Int,
     val effect: String,
-    val lore: String,
+    val lore: SpellLore?,
+    val customLore: String,
     val isVisibleToPlayers: Boolean = true,
 ) {
     init {
@@ -26,7 +28,7 @@ data class SpellImport(
         target.requireMaxLength(Spell.TARGET_MAX_LENGTH, "spell target")
         duration.requireMaxLength(Spell.DURATION_MAX_LENGTH, "spell duration")
         effect.requireMaxLength(Spell.EFFECT_MAX_LENGTH, "spell effect")
-        lore.requireMaxLength(Spell.LORE_MAX_LENGTH, "spell lore")
+        customLore.requireMaxLength(Spell.LORE_MAX_LENGTH, "spell lore")
     }
 
     fun toSpell() = Spell(
@@ -37,6 +39,7 @@ data class SpellImport(
         duration = duration,
         castingNumber = castingNumber,
         effect = effect,
+        customLore = customLore,
         lore = lore,
         isVisibleToPlayers = isVisibleToPlayers,
     )
@@ -50,6 +53,7 @@ data class SpellImport(
             castingNumber = spell.castingNumber,
             effect = spell.effect,
             lore = spell.lore,
+            customLore = spell.customLore,
             isVisibleToPlayers = spell.isVisibleToPlayers,
         )
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellDetailScreen.kt
@@ -26,6 +26,7 @@ class SpellDetailScreen(
                     effectiveCastingNumber = it.castingNumber,
                     range = it.range,
                     target = it.target,
+                    lore = it.lore,
                     duration = it.duration,
                     effect = it.effect,
                 )

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/spell/SpellDialog.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -15,8 +18,10 @@ import com.benasher44.uuid.uuid4
 import cz.frantisekmasa.wfrp_master.common.compendium.CompendiumItemDialog
 import cz.frantisekmasa.wfrp_master.common.compendium.CompendiumItemFormData
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.Spell
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.SpellLore
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.InputValue
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.Rules
+import cz.frantisekmasa.wfrp_master.common.core.ui.forms.SelectBox
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.TextInput
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.inputValue
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
@@ -30,10 +35,10 @@ fun SpellDialog(
 ) {
     val formData = SpellFormData.fromItem(spell)
 
-    val strings = LocalStrings.current.spells
+    val strings = LocalStrings.current
 
     CompendiumItemDialog(
-        title = if (spell == null) strings.titleAdd else strings.titleEdit,
+        title = if (spell == null) strings.spells.titleAdd else strings.spells.titleEdit,
         formData = formData,
         saver = onSaveRequest,
         onDismissRequest = onDismissRequest,
@@ -43,42 +48,52 @@ fun SpellDialog(
             modifier = Modifier.padding(Spacing.bodyPadding),
         ) {
             TextInput(
-                label = strings.labelName,
+                label = strings.spells.labelName,
                 value = formData.name,
                 validate = validate,
                 maxLength = Spell.NAME_MAX_LENGTH
             )
 
+            SelectBox(
+                label = strings.spells.labelLore,
+                value = formData.lore.value,
+                onValueChange = { formData.lore.value = it },
+                items = remember(strings) {
+                    SpellLore.values().map { it to it.nameResolver(strings) }
+                        .sortedBy { it.second } + (null to strings.spells.lores.other)
+                },
+            )
+
             TextInput(
-                label = strings.labelLore,
-                value = formData.lore,
+                label = strings.spells.labelLoreLegacy,
+                value = formData.customLore,
                 validate = validate,
                 maxLength = Spell.LORE_MAX_LENGTH
             )
 
             TextInput(
-                label = strings.labelRange,
+                label = strings.spells.labelRange,
                 value = formData.range,
                 validate = validate,
                 maxLength = Spell.RANGE_MAX_LENGTH,
             )
 
             TextInput(
-                label = strings.labelTarget,
+                label = strings.spells.labelTarget,
                 value = formData.target,
                 validate = validate,
                 maxLength = Spell.TARGET_MAX_LENGTH,
             )
 
             TextInput(
-                label = strings.labelDuration,
+                label = strings.spells.labelDuration,
                 value = formData.duration,
                 validate = validate,
                 maxLength = Spell.DURATION_MAX_LENGTH,
             )
 
             TextInput(
-                label = strings.labelCastingNumber,
+                label = strings.spells.labelCastingNumber,
                 value = formData.castingNumber,
                 keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
                 validate = validate,
@@ -86,7 +101,7 @@ fun SpellDialog(
             )
 
             TextInput(
-                label = strings.labelEffect,
+                label = strings.spells.labelEffect,
                 value = formData.effect,
                 validate = validate,
                 maxLength = Spell.EFFECT_MAX_LENGTH,
@@ -100,8 +115,10 @@ fun SpellDialog(
 @Stable
 private data class SpellFormData(
     val id: Uuid,
+    val isNew: Boolean,
     val name: InputValue,
-    val lore: InputValue,
+    val customLore: InputValue,
+    val lore: MutableState<SpellLore?>,
     val range: InputValue,
     val target: InputValue,
     val duration: InputValue,
@@ -113,8 +130,10 @@ private data class SpellFormData(
         @Composable
         fun fromItem(item: Spell?) = SpellFormData(
             id = remember(item) { item?.id ?: uuid4() },
+            isNew = item == null,
             name = inputValue(item?.name ?: "", Rules.NotBlank()),
-            lore = inputValue(item?.lore ?: ""),
+            customLore = inputValue(item?.customLore ?: ""),
+            lore = rememberSaveable(item) { mutableStateOf(item?.lore) },
             range = inputValue(item?.range ?: ""),
             target = inputValue(item?.target ?: ""),
             duration = inputValue(item?.duration ?: ""),
@@ -131,6 +150,7 @@ private data class SpellFormData(
         id = id,
         name = name.value,
         lore = lore.value,
+        customLore = customLore.value,
         range = range.value,
         target = target.value,
         duration = duration.value,
@@ -140,5 +160,6 @@ private data class SpellFormData(
     )
 
     override fun isValid() =
-        listOf(name, lore, range, target, duration, castingNumber, effect).all { it.isValid() }
+        listOf(name, customLore, range, target, duration, castingNumber, effect).all { it.isValid() } &&
+            (lore.value != null || !isNew)
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/spells/Spell.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/spells/Spell.kt
@@ -3,6 +3,7 @@ package cz.frantisekmasa.wfrp_master.common.core.domain.spells
 import androidx.compose.runtime.Immutable
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.SpellLore
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterItem
 import cz.frantisekmasa.wfrp_master.common.core.shared.Parcelize
 import kotlinx.serialization.Contextual
@@ -21,6 +22,7 @@ data class Spell(
     val duration: String,
     val castingNumber: Int,
     val effect: String,
+    val lore: SpellLore? = null,
     val memorized: Boolean = true, // TODO: Remove default value and migrate stored data
 ) : CharacterItem<Spell, CompendiumSpell> {
 
@@ -69,6 +71,7 @@ data class Spell(
                 duration = spell.duration,
                 castingNumber = spell.castingNumber,
                 effect = spell.effect,
+                lore = spell.lore,
                 memorized = false,
             )
         }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/cards/CardItem.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/cards/CardItem.kt
@@ -15,6 +15,7 @@ fun CardItem(
     onClick: () -> Unit,
     contextMenuItems: List<ContextMenu.Item> = emptyList(),
     badge: @Composable () -> Unit = {},
+    showDivider: Boolean = true,
 ) {
     WithContextMenu(
         items = contextMenuItems,
@@ -28,5 +29,7 @@ fun CardItem(
         )
     }
 
-    Divider()
+    if (showDivider) {
+        Divider()
+    }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/localization/Strings.kt
@@ -930,6 +930,7 @@ data class SpellStrings(
     val labelDuration: String = "Duration",
     val labelEffect: String = "Effect",
     val labelLore: String = "Lore",
+    val labelLoreLegacy: String = "Lore (Legacy)",
     val labelMemorized: String = "Memorized",
     val labelName: String = "Name",
     val labelRange: String = "Range",
@@ -940,6 +941,27 @@ data class SpellStrings(
     val titleEdit: String = "Edit Spell",
     val titleNew: String = "New Spell",
     val titleSpells: String = "Spells",
+    val lores: SpellLoreStrings = SpellLoreStrings(),
+)
+
+data class SpellLoreStrings(
+    val beasts: String = "Beasts",
+    val death: String = "Death",
+    val fire: String = "Fire",
+    val heavens: String = "Heavens",
+    val metal: String = "Metal",
+    val life: String = "Life",
+    val light: String = "Light",
+    val shadows: String = "Shadows",
+    val hedgecraft: String = "Hedgecraft",
+    val witchcraft: String = "Witchcraft",
+    val daemonology: String = "Daemonology",
+    val necromancy: String = "Necromancy",
+    val nurgle: String = "Nurgle",
+    val slaanesh: String = "Slaanesh",
+    val tzeentch: String = "Tzeentch",
+    val petty: String = "Petty Spells",
+    val other: String = "Other",
 )
 
 @Immutable

--- a/common/src/jvmTest/kotlin/ImporterTest.kt
+++ b/common/src/jvmTest/kotlin/ImporterTest.kt
@@ -1,3 +1,4 @@
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.SpellLore
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.books.CoreRulebook
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.books.EnemyInShadowsCompanion
 import cz.frantisekmasa.wfrp_master.common.compendium.domain.importer.books.UpInArms
@@ -73,7 +74,19 @@ class ImporterTest {
     fun `spell import (Core Rulebook)`() {
         withCoreRuleBook { document ->
             val spells = CoreRulebook.importSpells(document)
-            assertEquals(135, spells.size)
+            assertEquals(
+                (
+                    23 * SpellLore.values().size + // Arcane Spells
+                        25 + // Petty Spells
+                        8 * 8 + // Color Spells
+                        2 + // Hedgecraft Spells
+                        10 + // Witchcraft Spells
+                        4 + // Daemonology Spells
+                        4 + // Necromancy Spells
+                        3 // Chaos Spells
+                    ),
+                spells.size
+            )
         }
     }
 
@@ -81,7 +94,13 @@ class ImporterTest {
     fun `spell import (Winds of Magic)`() {
         withWindsOfMagic { document ->
             val spells = WindsOfMagic.importSpells(document)
-            assertEquals(8 + (8 * 24), spells.size)
+            assertEquals(
+                (
+                    8 * SpellLore.values().size + // Arcane Spells
+                        (8 * 24) // Color spells
+                    ),
+                spells.size
+            )
         }
     }
 
@@ -89,7 +108,13 @@ class ImporterTest {
     fun `spell import (Enemy in Shadows - Companion)`() {
         withEnemyInShadowsCompanion { document ->
             val spells = EnemyInShadowsCompanion.importSpells(document)
-            assertEquals(9 + 14, spells.size)
+            assertEquals(
+                (
+                    9 * 4 + // Chaos Arcane Spells
+                        14 // Tzeentch Spells
+                    ),
+                spells.size,
+            )
         }
     }
 

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -81,6 +81,7 @@ service cloud.firestore {
                        "castingNumber",
                        "effect",
                        "lore",
+                       "loreType",
                        "isVisibleToPlayers"
                     ].hasAll(spell.keys())
                         && spell.id is string && spell.id == spellId && isValidUuid(spell.id)
@@ -91,6 +92,7 @@ service cloud.firestore {
                         && spell.effect is string && spell.effect.size() <= 1500
                         && spell.castingNumber is int && spell.castingNumber >= 0 && spell.castingNumber <= 99
                         && spell.lore is string && spell.lore.size() <= 50
+                        && (! ("loreType" in spell) || spell.loreType is string || spell.loreType == null)
                         && (! ("isVisibleToPlayers" in spell) || spell.isVisibleToPlayers is bool);
                 }
             }
@@ -386,11 +388,23 @@ service cloud.firestore {
                     allow delete: if canEditCharacter();
 
                     function isValidSpell(spell) {
-                        return ["id", "name", "range", "target", "duration", "castingNumber", "effect", "compendiumId", "memorized"].hasAll(spell.keys())
+                        return [
+                           "id",
+                           "name",
+                           "range",
+                           "target",
+                           "lore",
+                           "duration",
+                           "castingNumber",
+                           "effect",
+                           "compendiumId",
+                           "memorized"
+                       ].hasAll(spell.keys())
                             && spell.id is string && spell.id == spellId && isValidUuid(spell.id)
                             && spell.name is string && isNotBlank(spell.name) && spell.name.size() <= 50
                             && spell.range is string && spell.range.size() <= 50
                             && spell.target is string && spell.target.size() <= 50
+                            && (! ("lore" in spell) || spell.lore is string || spell.lore == null)
                             && spell.duration is string && spell.duration.size() <= 50
                             && spell.effect is string && spell.effect.size() <= 1500
                             && spell.castingNumber is int && spell.castingNumber >= 0 && spell.castingNumber <= 99

--- a/firebase/list_lores.ts
+++ b/firebase/list_lores.ts
@@ -1,0 +1,3 @@
+const { initializeApp } = require("firebase-admin/app");
+
+initializeApp();


### PR DESCRIPTION
This MR adds Spell Lore as a new field for Character Spells.

For Compendium Spells there are now two fields:

- *Lore (legacy)* - this is text value, that wasn't visible anywhere
- *Lore* - select box

This also brings changes to Spell import - Arcane Spells are now imported as multiple Spells (e.g. `Blast` is now imported as `Blast (Shadows)`, `Blast (Light)`, etc. as well as generic `Blast`). This is consistent with the rules as Arcane Spells are always purchased for each Lore separately.

All existing Spells are treated as `Lore: Other`, so I strongly recommend all GMs reimport all sourcebooks they use. This will automatically update Lore values.

The new Lores are also used in Character UI - Spells are now grouped into Cards by their Lore.

---

I also plan to do automatic migration, so many of these Spells will be automatically updated in a few weeks.