### PR TITLE
Save all new compendium items in batch

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CharacterItemCompendiumItemScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/CharacterItemCompendiumItemScreenModel.kt
@@ -16,12 +16,6 @@ abstract class CharacterItemCompendiumItemScreenModel<A : CompendiumItem<A>, B :
     protected val characterItems: CharacterCompendiumItemRepository<B>
 ) : CompendiumItemScreenModel<A>(partyId, compendium) {
 
-    override suspend fun createNew(compendiumItem: A) {
-        firestore.runTransaction { transaction ->
-            compendium.save(transaction, partyId, compendiumItem)
-        }
-    }
-
     override suspend fun update(compendiumItem: A) {
         val characterItems = characterItems.findByCompendiumId(partyId, compendiumItem.id)
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/ImportDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/ImportDialog.kt
@@ -258,6 +258,7 @@ private fun <T : CompendiumItem<T>> ItemPicker(
                                                     else ImportAction.CreateNew(it)
                                                 }
                                                 .distinctBy { it.item.id }
+                                                .toList()
                                         )
                                     }
                                 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerCompendiumScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerCompendiumScreenModel.kt
@@ -19,23 +19,17 @@ class CareerCompendiumScreenModel(
 ) : CompendiumItemScreenModel<Career>(partyId, compendium) {
     val careers: Flow<List<Career>> = compendium.liveForParty(partyId)
 
-    override suspend fun createNew(compendiumItem: Career) {
-        firestore.runTransaction { transaction ->
-            compendium.save(transaction, partyId, compendiumItem)
-        }
-    }
-
     suspend fun saveLevel(careerId: Uuid, level: Career.Level) {
         val career = compendium.getItem(partyId, careerId)
         val existingIndex = career.levels.indexOfFirst { it.id == level.id }
 
         if (existingIndex == -1) {
-            compendium.saveItems(partyId, career.copy(levels = career.levels + level))
+            compendium.saveItems(partyId, listOf(career.copy(levels = career.levels + level)))
         } else {
             val levels = career.levels.toMutableList()
             levels[existingIndex] = level
 
-            compendium.saveItems(partyId, career.copy(levels = levels))
+            compendium.saveItems(partyId, listOf(career.copy(levels = levels)))
         }
     }
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/career/CareerScreenModel.kt
@@ -18,7 +18,7 @@ class CareerScreenModel(
     }
 
     suspend fun update(partyId: PartyId, career: Career) {
-        careerCompendium.saveItems(partyId, career)
+        careerCompendium.saveItems(partyId, listOf(career))
     }
 
     suspend fun saveLevel(partyId: PartyId, careerId: Uuid, level: Career.Level) {
@@ -29,7 +29,7 @@ class CareerScreenModel(
         if (existingIndex == -1) {
             careerCompendium.saveItems(
                 partyId,
-                career.copy(levels = career.levels + level)
+                listOf(career.copy(levels = career.levels + level)),
             )
         } else {
             val levels = career.levels.toMutableList()
@@ -37,7 +37,7 @@ class CareerScreenModel(
 
             careerCompendium.saveItems(
                 partyId,
-                career.copy(levels = levels)
+                listOf(career.copy(levels = levels)),
             )
         }
     }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/compendium/Compendium.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/compendium/Compendium.kt
@@ -22,7 +22,7 @@ interface Compendium<T : CompendiumItem<T>> {
     /**
      * Updates item if it exists and creates it if it doesn't
      */
-    suspend fun saveItems(partyId: PartyId, vararg items: T)
+    suspend fun saveItems(partyId: PartyId, items: List<T>)
 
     fun save(transaction: Transaction, partyId: PartyId, item: T)
 


### PR DESCRIPTION
This significantly speeds up the initial import.
I plan to optimize this even further as I know that changes introduced in #82 slowed down the import by orders of magnitude (providing better result though). 