### PR TITLE
Sync character spell lore when compendium spell is saved

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/spells/Spell.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/spells/Spell.kt
@@ -49,6 +49,7 @@ data class Spell(
             duration = compendiumItem.duration,
             castingNumber = compendiumItem.castingNumber,
             effect = compendiumItem.effect,
+            lore = compendiumItem.lore,
         )
     }
 


### PR DESCRIPTION
This is bug introduced in https://github.com/fmasa/wfrp-master/pull/124, so this did not hit production yet.