### PR TITLE
Improved names for Trappings

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/combat/ArmourCard.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/combat/ArmourCard.kt
@@ -176,7 +176,12 @@ private fun Location(
                 ListItem(
                     modifier = Modifier.clickable { onTrappingClick(item.trapping) },
                     text = { Text(item.trapping.name) },
-                    secondaryText = if (armour.qualities.isNotEmpty() || armour.flaws.isNotEmpty())
+                    secondaryText = if (
+                        armour.qualities.isNotEmpty() ||
+                        armour.flaws.isNotEmpty() ||
+                        item.trapping.itemQualities.isNotEmpty() ||
+                        item.trapping.itemFlaws.isNotEmpty()
+                    )
                         (
                             {
                                 TrappingFeatureList(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/combat/WeaponsCard.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/combat/WeaponsCard.kt
@@ -69,7 +69,12 @@ private fun WeaponList(weapons: List<EquippedWeapon>, onTrappingClick: (Inventor
                 modifier = Modifier.clickable { onTrappingClick(equippedWeapon.trapping) },
                 icon = { ItemIcon(trappingIcon(equippedWeapon.weapon), ItemIcon.Size.Small) },
                 text = { Text(equippedWeapon.trapping.name) },
-                secondaryText = if (weapon.qualities.isNotEmpty() || weapon.flaws.isNotEmpty())
+                secondaryText = if (
+                    weapon.qualities.isNotEmpty() ||
+                    weapon.flaws.isNotEmpty() ||
+                    equippedWeapon.trapping.itemQualities.isNotEmpty() ||
+                    equippedWeapon.trapping.itemFlaws.isNotEmpty()
+                )
                     (
                         {
                             TrappingFeatureList(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/trappings/TrappingItem.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/trappings/TrappingItem.kt
@@ -12,11 +12,13 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.trappings.TrappingsScreenModel.TrappingItem
+import cz.frantisekmasa.wfrp_master.common.core.domain.localizedName
 import cz.frantisekmasa.wfrp_master.common.core.domain.trappings.Encumbrance
 import cz.frantisekmasa.wfrp_master.common.core.domain.trappings.sum
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
@@ -67,7 +69,24 @@ fun TrappingItem(
     ListItem(
         modifier = modifier,
         icon = { ItemIcon(trappingIcon(trapping.item.trappingType), ItemIcon.Size.Small) },
-        text = { Text(trapping.item.name) },
+        text = {
+            Text(
+                buildString {
+                    append(trapping.item.name)
+
+                    val itemFeatures = trapping.item.itemQualities + trapping.item.itemFlaws
+
+                    if (trapping.item.compendiumId != null && itemFeatures.isNotEmpty()) {
+                        val featureNames = itemFeatures.map { it.localizedName }
+                        val sorted = remember(featureNames) { featureNames.sorted() }
+
+                        append(" (")
+                        append(sorted.joinToString(", "))
+                        append(')')
+                    }
+                }
+            )
+        },
         trailing = {
             Column(horizontalAlignment = Alignment.End) {
                 if (trapping.item.quantity > 1) {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/trappings/InventoryItem.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/trappings/InventoryItem.kt
@@ -80,7 +80,7 @@ data class InventoryItem(
 
     fun duplicate(): InventoryItem = copy(
         id = uuid4(),
-        name = duplicateName(name),
+        name = if (compendiumId == null) duplicateName(name) else name,
     )
 
     fun addToContainer(containerId: InventoryItemId): InventoryItem {


### PR DESCRIPTION
- When duplicating Trapping imported from Compendium `(Copy)` is not appended anymore (this could not be removed and is generally something you probably don't want). In future this should probably be changed, so that duplicating unlinks the Trapping from Compendium and there is a different option to create Character Trapping from Compendium trapping (so Player take Hand Weapon and change some things )
- Item qualities & flaws are shown in Trapping list
- Fixed showing of qualities & flaws in combat screen, when item only has item qualities