### PR TITLE
Hide Hardy checkbox for Characters without this mechanism

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterEdit/MaxWoundsSection.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterEdit/MaxWoundsSection.kt
@@ -48,15 +48,17 @@ fun MaxWoundsSection(character: Character, screenModel: CharacterScreenModel) {
                 placeholder = stringResource(Str.points_auto_max_wounds_placeholder),
             )
 
-            if (formData.hardyTalent.value) {
-                UserTipCard(UserTip.HARDY_TALENTS)
-            }
+            if (character.hasHardyTalent) {
+                if (formData.hardyTalent.value) {
+                    UserTipCard(UserTip.HARDY_TALENTS)
+                }
 
-            CheckboxWithText(
-                text = stringResource(Str.points_label_hardy),
-                checked = formData.hardyTalent.value,
-                onCheckedChange = { formData.hardyTalent.value = it }
-            )
+                CheckboxWithText(
+                    text = stringResource(Str.points_label_hardy),
+                    checked = formData.hardyTalent.value,
+                    onCheckedChange = { formData.hardyTalent.value = it }
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/fmasa/wfrp-master/issues/185
Hides hardy checkbox from UI altogether for most of the users. In the next release I plan to remove it completely.