### PR TITLE
Unify behavior after character item is created

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CompendiumItemChooser.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CompendiumItemChooser.kt
@@ -10,7 +10,11 @@ import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cz.frantisekmasa.wfrp_master.common.Str
@@ -39,6 +43,7 @@ internal fun <T : CompendiumItem<T>> CompendiumItemChooser(
     emptyUiIcon: Resources.Drawable,
 ) {
     val coroutineScope = rememberCoroutineScope()
+    var processing by remember { mutableStateOf(false) }
 
     Column(Modifier.fillMaxSize()) {
         SearchableList(
@@ -64,7 +69,14 @@ internal fun <T : CompendiumItem<T>> CompendiumItemChooser(
             ListItem(
                 modifier = Modifier.clickable(
                     onClick = {
-                        coroutineScope.launch(Dispatchers.IO) { onSelect(item) }
+                        processing = true
+                        coroutineScope.launch(Dispatchers.IO) {
+                            try {
+                                onSelect(item)
+                            } finally {
+                                processing = false
+                            }
+                        }
                     }
                 ),
                 icon = {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/items/AddItemUi.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/items/AddItemUi.kt
@@ -1,0 +1,125 @@
+package cz.frantisekmasa.wfrp_master.common.character.items
+
+import androidx.compose.material.Scaffold
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.SnackbarResult
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import cafe.adriel.voyager.core.screen.Screen
+import cz.frantisekmasa.wfrp_master.common.Str
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.CompendiumItem
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterItem
+import cz.frantisekmasa.wfrp_master.common.core.ui.navigation.LocalNavigationTransaction
+import cz.frantisekmasa.wfrp_master.common.core.ui.navigation.NavigationTransaction
+import dev.icerock.moko.parcelize.Parcelable
+import dev.icerock.moko.parcelize.Parcelize
+import dev.icerock.moko.resources.compose.stringResource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@Composable
+fun <A : CharacterItem<A, B>, B : CompendiumItem<B>> rememberAddItemUiState(
+    saver: suspend (A) -> Unit,
+    detailScreenFactory: (A) -> Screen,
+): AddItemUiState<A, B> {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val step = rememberSaveable {
+        mutableStateOf<AddItemUiState.Step<B>>(AddItemUiState.Step.ChoosingCompendiumItems)
+    }
+    val successMessageText = stringResource(Str.common_ui_item_added)
+    val detailButtonText = stringResource(Str.common_ui_button_open)
+    val coroutineScope = rememberCoroutineScope()
+    val navigation = LocalNavigationTransaction.current
+
+    return remember {
+        AddItemUiState(
+            step,
+            saver,
+            detailScreenFactory,
+            detailButtonText = detailButtonText,
+            successMessageText = successMessageText,
+            snackbarHostState = snackbarHostState,
+            coroutineScope = coroutineScope,
+            navigation = navigation,
+        )
+    }
+}
+
+@Stable
+class AddItemUiState<A : CharacterItem<A, B>, B : CompendiumItem<B>>(
+    private val _step: MutableState<Step<B>>,
+    private val saver: suspend (A) -> Unit,
+    val detailScreenFactory: (A) -> Screen,
+    private val detailButtonText: String,
+    private val successMessageText: String,
+    val snackbarHostState: SnackbarHostState,
+    private val coroutineScope: CoroutineScope,
+    private val navigation: NavigationTransaction,
+) {
+    val step: Step<B> @Composable get() = _step.value
+
+    fun openNonCompendiumItemForm() {
+        _step.value = Step.CreatingNonCompendiumItem
+    }
+
+    fun openChoosingScreen() {
+        _step.value = Step.ChoosingCompendiumItems
+    }
+
+    fun openSpecificationScreen(item: B) {
+        _step.value = Step.CompendiumItemSpecification(item)
+    }
+
+    suspend fun saveItem(item: A) {
+        saver(item)
+        coroutineScope.launch {
+            val result = snackbarHostState.showSnackbar(
+                message = successMessageText,
+                actionLabel = detailButtonText,
+            )
+
+            if (result == SnackbarResult.ActionPerformed) {
+                navigation.replace(detailScreenFactory(item))
+            }
+        }
+    }
+
+    sealed interface Step<out T : CompendiumItem<out T>> : Parcelable {
+        @Parcelize
+        object ChoosingCompendiumItems : Step<Nothing>
+        @Parcelize
+        object CreatingNonCompendiumItem : Step<Nothing>
+        @Parcelize
+        data class CompendiumItemSpecification<T : CompendiumItem<T>>(val item: T) : Step<T>
+    }
+}
+
+@Composable
+fun <A : CharacterItem<A, B>, B : CompendiumItem<B>> AddItemUi(
+    state: AddItemUiState<A, B>,
+    chooser: @Composable () -> Unit,
+    specification: @Composable (compendiumItem: B) -> Unit,
+    nonCompendiumItemForm: @Composable () -> Unit,
+) {
+    Scaffold(scaffoldState = rememberScaffoldState(snackbarHostState = state.snackbarHostState)) {
+        when (val step = state.step) {
+            AddItemUiState.Step.ChoosingCompendiumItems -> {
+                chooser()
+            }
+
+            AddItemUiState.Step.CreatingNonCompendiumItem -> {
+                nonCompendiumItemForm()
+            }
+
+            is AddItemUiState.Step.CompendiumItemSpecification -> {
+                specification(step.item)
+            }
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/religion/blessings/add/AddBlessingScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/religion/blessings/add/AddBlessingScreen.kt
@@ -1,11 +1,12 @@
 package cz.frantisekmasa.wfrp_master.common.character.religion.blessings.add
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import cafe.adriel.voyager.core.screen.Screen
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.CompendiumItemChooser
+import cz.frantisekmasa.wfrp_master.common.character.items.AddItemUi
+import cz.frantisekmasa.wfrp_master.common.character.items.rememberAddItemUiState
+import cz.frantisekmasa.wfrp_master.common.character.religion.blessings.CharacterBlessingDetailScreen
 import cz.frantisekmasa.wfrp_master.common.character.religion.blessings.dialog.NonCompendiumBlessingForm
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.religion.Blessing
@@ -14,8 +15,6 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
 import cz.frantisekmasa.wfrp_master.common.core.ui.navigation.LocalNavigationTransaction
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
-import dev.icerock.moko.parcelize.Parcelable
-import dev.icerock.moko.parcelize.Parcelize
 import dev.icerock.moko.resources.compose.stringResource
 
 class AddBlessingScreen(
@@ -27,44 +26,39 @@ class AddBlessingScreen(
         val screenModel: AddBlessingScreenModel = rememberScreenModel(arg = characterId)
         val state = screenModel.state.collectWithLifecycle(null).value
 
-        val (step, setStep) = rememberSaveable {
-            mutableStateOf<Step>(Step.ChoosingCompendiumMiracle)
-        }
-
         if (state == null) {
             FullScreenProgress()
             return
         }
 
-        when (step) {
-            Step.ChoosingCompendiumMiracle -> {
-                val navigation = LocalNavigationTransaction.current
+        val addItemUiState = rememberAddItemUiState(
+            saver = screenModel::addBlessing,
+            detailScreenFactory = { CharacterBlessingDetailScreen(characterId, it.id) },
+        )
 
+        AddItemUi(
+            state = addItemUiState,
+            chooser = {
+                val navigation = LocalNavigationTransaction.current
                 CompendiumItemChooser(
                     state = state.availableCompendiumItems,
                     title = stringResource(Str.blessings_title_choose_compendium_blessing),
                     onDismissRequest = navigation::goBack,
                     icon = { Resources.Drawable.Blessing },
-                    onSelect = { screenModel.addBlessing(Blessing.fromCompendium(it)) },
-                    onCustomItemRequest = { setStep(Step.FillingInCustomBlessing) },
+                    onSelect = { addItemUiState.saveItem(Blessing.fromCompendium(it)) },
+                    onCustomItemRequest = addItemUiState::openNonCompendiumItemForm,
                     customItemButtonText = stringResource(Str.blessings_button_add_non_compendium),
                     emptyUiIcon = Resources.Drawable.Blessing,
                 )
+            },
+            specification = { error("There is no specification for blessings") },
+            nonCompendiumItemForm = {
+                NonCompendiumBlessingForm(
+                    existingBlessing = null,
+                    onDismissRequest = addItemUiState::openChoosingScreen,
+                    onSave = screenModel::addBlessing,
+                )
             }
-
-            Step.FillingInCustomBlessing -> NonCompendiumBlessingForm(
-                existingBlessing = null,
-                onDismissRequest = { setStep(Step.ChoosingCompendiumMiracle) },
-                onSave = screenModel::addBlessing,
-            )
-        }
-    }
-
-    private sealed class Step : Parcelable {
-        @Parcelize
-        object ChoosingCompendiumMiracle : Step()
-
-        @Parcelize
-        object FillingInCustomBlessing : Step()
+        )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/religion/miracles/add/AddMiracleScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/religion/miracles/add/AddMiracleScreen.kt
@@ -1,11 +1,12 @@
 package cz.frantisekmasa.wfrp_master.common.character.religion.miracles.add
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import cafe.adriel.voyager.core.screen.Screen
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.CompendiumItemChooser
+import cz.frantisekmasa.wfrp_master.common.character.items.AddItemUi
+import cz.frantisekmasa.wfrp_master.common.character.items.rememberAddItemUiState
+import cz.frantisekmasa.wfrp_master.common.character.religion.miracles.CharacterMiracleDetailScreen
 import cz.frantisekmasa.wfrp_master.common.character.religion.miracles.dialog.NonCompendiumMiracleForm
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.religion.Miracle
@@ -14,8 +15,6 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
 import cz.frantisekmasa.wfrp_master.common.core.ui.navigation.LocalNavigationTransaction
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
-import dev.icerock.moko.parcelize.Parcelable
-import dev.icerock.moko.parcelize.Parcelize
 import dev.icerock.moko.resources.compose.stringResource
 
 class AddMiracleScreen(
@@ -27,45 +26,39 @@ class AddMiracleScreen(
         val screenModel: AddMiracleScreenModel = rememberScreenModel(arg = characterId)
         val state = screenModel.state.collectWithLifecycle(null).value
 
-        val (step, setStep) = rememberSaveable {
-            mutableStateOf<Step>(Step.ChoosingCompendiumMiracle)
-        }
-
         if (state == null) {
             FullScreenProgress()
             return
         }
 
-        when (step) {
-            Step.ChoosingCompendiumMiracle -> {
-                val navigation = LocalNavigationTransaction.current
+        val addItemUiState = rememberAddItemUiState(
+            saver = screenModel::addMiracle,
+            detailScreenFactory = { CharacterMiracleDetailScreen(characterId, it.id) },
+        )
 
+        AddItemUi(
+            state = addItemUiState,
+            chooser = {
+                val navigation = LocalNavigationTransaction.current
                 CompendiumItemChooser(
                     state = state.availableCompendiumItems,
                     title = stringResource(Str.miracles_title_choose_compendium_miracle),
                     onDismissRequest = navigation::goBack,
                     icon = { Resources.Drawable.Miracle },
-                    onSelect = { screenModel.addMiracle(Miracle.fromCompendium(it)) },
-                    onCustomItemRequest = { setStep(Step.FillingInCustomMiracle) },
+                    onSelect = { addItemUiState.saveItem(Miracle.fromCompendium(it)) },
+                    onCustomItemRequest = addItemUiState::openNonCompendiumItemForm,
                     customItemButtonText = stringResource(Str.miracles_button_add_non_compendium),
                     emptyUiIcon = Resources.Drawable.Miracle,
                 )
+            },
+            specification = { error("There is no specification for miracles") },
+            nonCompendiumItemForm = {
+                NonCompendiumMiracleForm(
+                    existingMiracle = null,
+                    onSave = screenModel::addMiracle,
+                    onDismissRequest = addItemUiState::openChoosingScreen,
+                )
             }
-
-            Step.FillingInCustomMiracle -> NonCompendiumMiracleForm(
-                existingMiracle = null,
-                onSave = screenModel::addMiracle,
-                onDismissRequest = { setStep(Step.ChoosingCompendiumMiracle) },
-            )
-        }
-    }
-
-    private sealed class Step : Parcelable {
-
-        @Parcelize
-        object ChoosingCompendiumMiracle : Step()
-
-        @Parcelize
-        object FillingInCustomMiracle : Step()
+        )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/skills/add/AddSkillScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/skills/add/AddSkillScreen.kt
@@ -1,23 +1,22 @@
 package cz.frantisekmasa.wfrp_master.common.character.skills.add
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import cafe.adriel.voyager.core.screen.Screen
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.CompendiumItemChooser
+import cz.frantisekmasa.wfrp_master.common.character.items.AddItemUi
+import cz.frantisekmasa.wfrp_master.common.character.items.rememberAddItemUiState
+import cz.frantisekmasa.wfrp_master.common.character.skills.CharacterSkillDetailScreen
 import cz.frantisekmasa.wfrp_master.common.character.skills.dialog.AdvancesForm
 import cz.frantisekmasa.wfrp_master.common.character.skills.dialog.NonCompendiumSkillForm
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
+import cz.frantisekmasa.wfrp_master.common.core.domain.skills.Skill
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
 import cz.frantisekmasa.wfrp_master.common.core.ui.navigation.LocalNavigationTransaction
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
-import dev.icerock.moko.parcelize.Parcelable
-import dev.icerock.moko.parcelize.Parcelize
 import dev.icerock.moko.resources.compose.stringResource
-import cz.frantisekmasa.wfrp_master.common.compendium.domain.Skill as CompendiumSkill
 
 class AddSkillScreen(
     private val characterId: CharacterId,
@@ -28,10 +27,6 @@ class AddSkillScreen(
         val screenModel: AddSkillScreenModel = rememberScreenModel(arg = characterId)
         val state = screenModel.state.collectWithLifecycle(null).value
 
-        val (step, setStep) = rememberSaveable {
-            mutableStateOf<Step>(Step.ChoosingCompendiumSkill)
-        }
-
         if (state == null) {
             FullScreenProgress()
             return
@@ -39,47 +34,46 @@ class AddSkillScreen(
 
         val navigation = LocalNavigationTransaction.current
 
-        when (step) {
-            Step.ChoosingCompendiumSkill -> {
+        val addItemUiState = rememberAddItemUiState(
+            saver = screenModel::addSkill,
+            detailScreenFactory = { CharacterSkillDetailScreen(characterId, it.id) },
+        )
+
+        AddItemUi(
+            state = addItemUiState,
+            chooser = {
                 CompendiumItemChooser(
                     state = state.availableCompendiumItems,
                     title = stringResource(Str.skills_title_choose_compendium_skill),
-                    onDismissRequest = { navigation.goBack() },
+                    onDismissRequest = navigation::goBack,
                     icon = { it.characteristic.getIcon() },
-                    onSelect = { setStep(Step.FillingInAdvances(it, it.advanced)) },
-                    onCustomItemRequest = { setStep(Step.FillingInCustomSkill) },
+                    onSelect = addItemUiState::openSpecificationScreen,
+                    onCustomItemRequest = addItemUiState::openNonCompendiumItemForm,
                     customItemButtonText = stringResource(Str.skills_button_add_non_compendium),
                     emptyUiIcon = Resources.Drawable.Skill,
                 )
-            }
-            is Step.FillingInAdvances ->
+            },
+            specification = { compendiumSkill ->
                 AdvancesForm(
-                    compendiumSkill = step.compendiumSkill,
+                    compendiumSkill = compendiumSkill,
                     characteristics = state.characteristics,
-                    isAdvanced = step.isAdvanced,
-                    onDismissRequest = { navigation.goBack() },
-                    onSave = { screenModel.addCompendiumSkill(step.compendiumSkill.id, it) }
+                    isAdvanced = compendiumSkill.advanced,
+                    onDismissRequest = addItemUiState::openChoosingScreen,
+                    onSave = {
+                        addItemUiState.saveItem(
+                            Skill.fromCompendium(compendiumSkill, advances = it)
+                        )
+                    }
                 )
-            is Step.FillingInCustomSkill -> NonCompendiumSkillForm(
-                onSave = screenModel::addCustomSkill,
-                existingSkill = null,
-                characteristics = state.characteristics,
-                onDismissRequest = { setStep(Step.ChoosingCompendiumSkill) },
-            )
-        }
-    }
-
-    private sealed class Step : Parcelable {
-        @Parcelize
-        class FillingInAdvances(
-            val compendiumSkill: CompendiumSkill,
-            val isAdvanced: Boolean,
-        ) : Step()
-
-        @Parcelize
-        object ChoosingCompendiumSkill : Step()
-
-        @Parcelize
-        object FillingInCustomSkill : Step()
+            },
+            nonCompendiumItemForm = {
+                NonCompendiumSkillForm(
+                    onSave = addItemUiState::saveItem,
+                    existingSkill = null,
+                    characteristics = state.characteristics,
+                    onDismissRequest = addItemUiState::openChoosingScreen,
+                )
+            }
+        )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/skills/add/AddSkillScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/skills/add/AddSkillScreenModel.kt
@@ -1,10 +1,7 @@
 package cz.frantisekmasa.wfrp_master.common.character.skills.add
 
 import cafe.adriel.voyager.core.model.ScreenModel
-import com.benasher44.uuid.Uuid
 import cz.frantisekmasa.wfrp_master.common.character.items.AvailableCompendiumItemsFactory
-import cz.frantisekmasa.wfrp_master.common.character.skills.dialog.AdvancesForm
-import cz.frantisekmasa.wfrp_master.common.compendium.domain.exceptions.CompendiumItemNotFound
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterItemRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.Compendium
@@ -40,28 +37,7 @@ class AddSkillScreenModel(
         )
     }
 
-    suspend fun addCustomSkill(skill: Skill) {
+    suspend fun addSkill(skill: Skill) {
         skills.save(characterId, skill)
-    }
-
-    suspend fun addCompendiumSkill(
-        compendiumSkillId: Uuid,
-        advances: Int,
-    ): AdvancesForm.SavingResult {
-        val compendiumSkill = try {
-            compendium.getItem(
-                partyId = characterId.partyId,
-                itemId = compendiumSkillId,
-            )
-        } catch (e: CompendiumItemNotFound) {
-            return AdvancesForm.SavingResult.COMPENDIUM_ITEM_WAS_REMOVED
-        }
-
-        skills.save(
-            characterId,
-            Skill.fromCompendium(compendiumSkill, advances),
-        )
-
-        return AdvancesForm.SavingResult.SUCCESS
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/skills/dialog/AdvancesForm.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/skills/dialog/AdvancesForm.kt
@@ -3,7 +3,6 @@ package cz.frantisekmasa.wfrp_master.common.character.skills.dialog
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
@@ -16,26 +15,22 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.skills.SkillRating
-import cz.frantisekmasa.wfrp_master.common.compendium.domain.Skill
 import cz.frantisekmasa.wfrp_master.common.core.domain.Stats
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.FormDialog
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.HydratedFormData
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.NumberPicker
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
-import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
 import dev.icerock.moko.resources.compose.stringResource
+import cz.frantisekmasa.wfrp_master.common.compendium.domain.Skill as CompendiumSkill
 
 @Composable
 internal fun AdvancesForm(
-    compendiumSkill: Skill,
+    compendiumSkill: CompendiumSkill,
     characteristics: Stats,
-    onSave: suspend (advances: Int) -> AdvancesForm.SavingResult,
+    onSave: suspend (advances: Int) -> Unit,
     isAdvanced: Boolean,
     onDismissRequest: () -> Unit,
 ) {
-    val messageCompendiumSkillRemoved = stringResource(Str.skills_messages_compendium_skill_removed)
-    val snackbarHolder = LocalPersistentSnackbarHolder.current
-
     val formData = AdvancesForm.Data(
         rememberSaveable(compendiumSkill.id) { mutableStateOf(1) },
     )
@@ -44,19 +39,7 @@ internal fun AdvancesForm(
         title = stringResource(Str.skills_title_new),
         onDismissRequest = onDismissRequest,
         formData = formData,
-        onSave = {
-            when (onSave(it)) {
-                AdvancesForm.SavingResult.SUCCESS -> {}
-                AdvancesForm.SavingResult.COMPENDIUM_ITEM_WAS_REMOVED -> {
-                    snackbarHolder.showSnackbar(
-                        messageCompendiumSkillRemoved,
-                        SnackbarDuration.Short,
-                    )
-                }
-            }
-
-            onDismissRequest()
-        }
+        onSave = onSave,
     ) {
         Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
             Text(
@@ -88,8 +71,6 @@ internal fun AdvancesForm(
 }
 
 object AdvancesForm {
-
-    enum class SavingResult { SUCCESS, COMPENDIUM_ITEM_WAS_REMOVED }
 
     @Stable
     data class Data(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/spells/add/AddSpellScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/spells/add/AddSpellScreen.kt
@@ -1,11 +1,12 @@
 package cz.frantisekmasa.wfrp_master.common.character.spells.add
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import cafe.adriel.voyager.core.screen.Screen
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.CompendiumItemChooser
+import cz.frantisekmasa.wfrp_master.common.character.items.AddItemUi
+import cz.frantisekmasa.wfrp_master.common.character.items.rememberAddItemUiState
+import cz.frantisekmasa.wfrp_master.common.character.spells.CharacterSpellDetailScreen
 import cz.frantisekmasa.wfrp_master.common.character.spells.dialog.NonCompendiumSpellForm
 import cz.frantisekmasa.wfrp_master.common.compendium.spell.SpellLoreIcon
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
@@ -26,38 +27,40 @@ class AddSpellScreen(
         val screenModel: AddSpellScreenModel = rememberScreenModel(arg = characterId)
         val state = screenModel.state.collectWithLifecycle(null).value
 
-        val (step, setStep) = rememberSaveable { mutableStateOf(Step.ChoosingCompendiumSpell) }
-
         if (state == null) {
             FullScreenProgress()
             return
         }
 
-        when (step) {
-            Step.ChoosingCompendiumSpell -> {
+        val addItemUiState = rememberAddItemUiState(
+            saver = screenModel::saveItem,
+            detailScreenFactory = { CharacterSpellDetailScreen(characterId, it.id) },
+        )
+        AddItemUi(
+            state = addItemUiState,
+            chooser = {
                 val navigation = LocalNavigationTransaction.current
-
                 CompendiumItemChooser(
                     state = state.availableCompendiumItems,
                     title = stringResource(Str.spells_title_choose_compendium_spell),
                     onDismissRequest = navigation::goBack,
                     customIcon = { SpellLoreIcon(it.lore) },
-                    onSelect = { screenModel.saveItem(Spell.fromCompendium(it)) },
-                    onCustomItemRequest = { setStep(Step.FillingInCustomSpell) },
+                    onSelect = { addItemUiState.saveItem(Spell.fromCompendium(it)) },
+                    onCustomItemRequest = addItemUiState::openNonCompendiumItemForm,
                     customItemButtonText = stringResource(Str.spells_button_add_non_compendium),
                     emptyUiIcon = Resources.Drawable.Spell,
                 )
+            },
+            specification = {
+                TODO("Implement specification form with 'memorized' checkbox")
+            },
+            nonCompendiumItemForm = {
+                NonCompendiumSpellForm(
+                    onSave = addItemUiState::saveItem,
+                    existingSpell = null,
+                    onDismissRequest = addItemUiState::openChoosingScreen,
+                )
             }
-            Step.FillingInCustomSpell -> NonCompendiumSpellForm(
-                onSave = screenModel::saveItem,
-                existingSpell = null,
-                onDismissRequest = { setStep(Step.ChoosingCompendiumSpell) },
-            )
-        }
-    }
-
-    private enum class Step {
-        ChoosingCompendiumSpell,
-        FillingInCustomSpell,
+        )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/add/AddTalentScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/add/AddTalentScreen.kt
@@ -1,22 +1,21 @@
 package cz.frantisekmasa.wfrp_master.common.character.talents.add
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import cafe.adriel.voyager.core.screen.Screen
-import com.benasher44.uuid.Uuid
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.CompendiumItemChooser
+import cz.frantisekmasa.wfrp_master.common.character.items.AddItemUi
+import cz.frantisekmasa.wfrp_master.common.character.items.rememberAddItemUiState
+import cz.frantisekmasa.wfrp_master.common.character.talents.CharacterTalentDetailScreen
 import cz.frantisekmasa.wfrp_master.common.character.talents.dialog.NonCompendiumTalentForm
 import cz.frantisekmasa.wfrp_master.common.character.talents.dialog.TimesTakenForm
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
+import cz.frantisekmasa.wfrp_master.common.core.domain.talents.Talent
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
 import cz.frantisekmasa.wfrp_master.common.core.ui.navigation.LocalNavigationTransaction
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
-import dev.icerock.moko.parcelize.Parcelable
-import dev.icerock.moko.parcelize.Parcelize
 import dev.icerock.moko.resources.compose.stringResource
 
 class AddTalentScreen(
@@ -28,54 +27,49 @@ class AddTalentScreen(
         val screenModel: AddTalentScreenModel = rememberScreenModel(arg = characterId)
         val state = screenModel.state.collectWithLifecycle(null).value
 
-        val (step, setStep) = rememberSaveable {
-            mutableStateOf<Step>(Step.ChoosingCompendiumTalent)
-        }
-
         if (state == null) {
             FullScreenProgress()
             return
         }
 
-        when (step) {
-            Step.ChoosingCompendiumTalent -> {
+        val addItemUiState = rememberAddItemUiState(
+            saver = screenModel::addTalent,
+            detailScreenFactory = { CharacterTalentDetailScreen(characterId, it.id) },
+        )
+
+        AddItemUi(
+            state = addItemUiState,
+            chooser = {
                 val navigation = LocalNavigationTransaction.current
                 CompendiumItemChooser(
                     state = state.availableCompendiumItems,
                     title = stringResource(Str.talents_title_choose_compendium_talent),
-                    onDismissRequest = { navigation.goBack() },
+                    onDismissRequest = navigation::goBack,
                     icon = { Resources.Drawable.Talent },
-                    onSelect = { setStep(Step.FillingInTimesTaken(it.id)) },
-                    onCustomItemRequest = { setStep(Step.FillingInCustomTalent) },
+                    onSelect = addItemUiState::openSpecificationScreen,
+                    onCustomItemRequest = { addItemUiState.openNonCompendiumItemForm() },
                     customItemButtonText = stringResource(Str.talents_button_add_non_compendium),
                     emptyUiIcon = Resources.Drawable.Talent,
                 )
-            }
-            is Step.FillingInTimesTaken ->
+            },
+            specification = { compendiumTalent ->
                 TimesTakenForm(
                     existingTalent = null,
                     onSave = {
-                        screenModel.addCompendiumTalent(step.compendiumTalentId, timesTaken = it)
+                        addItemUiState.saveItem(
+                            Talent.fromCompendium(compendiumTalent, timesTaken = it)
+                        )
                     },
-                    onDismissRequest = { setStep(Step.ChoosingCompendiumTalent) },
+                    onDismissRequest = addItemUiState::openChoosingScreen,
                 )
-            is Step.FillingInCustomTalent -> NonCompendiumTalentForm(
-                existingTalent = null,
-                onSave = screenModel::addTalent,
-                onDismissRequest = { setStep(Step.ChoosingCompendiumTalent) },
-            )
-        }
-    }
-
-    private sealed class Step : Parcelable {
-
-        @Parcelize
-        class FillingInTimesTaken(val compendiumTalentId: Uuid) : Step()
-
-        @Parcelize
-        object ChoosingCompendiumTalent : Step()
-
-        @Parcelize
-        object FillingInCustomTalent : Step()
+            },
+            nonCompendiumItemForm = {
+                NonCompendiumTalentForm(
+                    existingTalent = null,
+                    onSave = screenModel::addTalent,
+                    onDismissRequest = addItemUiState::openChoosingScreen,
+                )
+            }
+        )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/add/AddTalentScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/add/AddTalentScreenModel.kt
@@ -1,12 +1,8 @@
 package cz.frantisekmasa.wfrp_master.common.character.talents.add
 
 import cafe.adriel.voyager.core.model.ScreenModel
-import com.benasher44.uuid.Uuid
-import com.benasher44.uuid.uuid4
 import cz.frantisekmasa.wfrp_master.common.character.effects.EffectManager
 import cz.frantisekmasa.wfrp_master.common.character.items.AvailableCompendiumItemsFactory
-import cz.frantisekmasa.wfrp_master.common.character.talents.dialog.TimesTakenForm
-import cz.frantisekmasa.wfrp_master.common.compendium.domain.exceptions.CompendiumItemNotFound
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterItemRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.Compendium
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
@@ -34,33 +30,6 @@ class AddTalentScreenModel(
         AddTalentScreenState(
             availableCompendiumItems = compendiumItemChooserState,
         )
-    }
-
-    suspend fun addCompendiumTalent(
-        compendiumTalentId: Uuid,
-        timesTaken: Int,
-    ): TimesTakenForm.SavingResult {
-        val compendiumTalent = try {
-            compendium.getItem(
-                partyId = characterId.partyId,
-                itemId = compendiumTalentId,
-            )
-        } catch (e: CompendiumItemNotFound) {
-            return TimesTakenForm.SavingResult.COMPENDIUM_ITEM_WAS_REMOVED
-        }
-
-        addTalent(
-            Talent(
-                id = uuid4(),
-                compendiumId = compendiumTalent.id,
-                name = compendiumTalent.name,
-                tests = compendiumTalent.tests,
-                description = compendiumTalent.description,
-                taken = timesTaken,
-            )
-        )
-
-        return TimesTakenForm.SavingResult.SUCCESS
     }
 
     suspend fun addTalent(talent: Talent) {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/dialog/TimesTakenForm.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/talents/dialog/TimesTakenForm.kt
@@ -17,22 +17,16 @@ import cz.frantisekmasa.wfrp_master.common.core.domain.talents.Talent
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.FormDialog
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.HydratedFormData
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.NumberPicker
-import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
 import dev.icerock.moko.resources.compose.stringResource
 
 @Composable
 internal fun TimesTakenForm(
     existingTalent: Talent?,
-    onSave: suspend (timesTaken: Int) -> TimesTakenForm.SavingResult,
+    onSave: suspend (timesTaken: Int) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
     val formData = TimesTakenForm.FormData(
         rememberSaveable { mutableStateOf(existingTalent?.taken ?: 1) }
-    )
-
-    val snackbarHolder = LocalPersistentSnackbarHolder.current
-    val successMessage = stringResource(
-        Str.talents_messages_compendium_talent_removed
     )
 
     FormDialog(
@@ -43,16 +37,7 @@ internal fun TimesTakenForm(
         ),
         formData = formData,
         onDismissRequest = onDismissRequest,
-        onSave = {
-            when (onSave(it)) {
-                TimesTakenForm.SavingResult.SUCCESS -> {}
-                TimesTakenForm.SavingResult.COMPENDIUM_ITEM_WAS_REMOVED -> {
-                    snackbarHolder.showSnackbar(successMessage)
-                }
-            }
-
-            onDismissRequest()
-        }
+        onSave = onSave,
     ) {
         Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
             Text(
@@ -73,8 +58,6 @@ internal fun TimesTakenForm(
 }
 
 object TimesTakenForm {
-    enum class SavingResult { SUCCESS, COMPENDIUM_ITEM_WAS_REMOVED }
-
     @Stable
     data class FormData(
         private val timesTakenState: MutableState<Int>,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/traits/add/AddTraitScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/traits/add/AddTraitScreen.kt
@@ -1,29 +1,21 @@
 package cz.frantisekmasa.wfrp_master.common.character.traits.add
 
-import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import cafe.adriel.voyager.core.screen.Screen
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.CompendiumItemChooser
+import cz.frantisekmasa.wfrp_master.common.character.items.AddItemUi
+import cz.frantisekmasa.wfrp_master.common.character.items.rememberAddItemUiState
+import cz.frantisekmasa.wfrp_master.common.character.traits.CharacterTraitDetailScreen
 import cz.frantisekmasa.wfrp_master.common.character.traits.dialog.TraitSpecificationsForm
-import cz.frantisekmasa.wfrp_master.common.compendium.domain.Trait
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
+import cz.frantisekmasa.wfrp_master.common.core.domain.traits.Trait
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
 import cz.frantisekmasa.wfrp_master.common.core.ui.navigation.LocalNavigationTransaction
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
-import dev.icerock.moko.parcelize.Parcelable
-import dev.icerock.moko.parcelize.Parcelize
 import dev.icerock.moko.resources.compose.stringResource
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 class AddTraitScreen(
     private val characterId: CharacterId,
@@ -34,29 +26,20 @@ class AddTraitScreen(
         val screenModel: AddTraitScreenModel = rememberScreenModel(arg = characterId)
         val state = screenModel.state.collectWithLifecycle(null).value
 
-        val (step, setStep) = rememberSaveable {
-            mutableStateOf<Step>(Step.ChoosingCompendiumTrait)
-        }
-
         if (state == null) {
             FullScreenProgress()
             return
         }
 
-        when (step) {
-            Step.ChoosingCompendiumTrait -> {
-                val coroutineScope = rememberCoroutineScope()
-                var saving by remember { mutableStateOf(false) }
+        val addItemUiState = rememberAddItemUiState(
+            saver = screenModel::saveNewTrait,
+            detailScreenFactory = { CharacterTraitDetailScreen(characterId, it.id) }
+        )
 
-                if (saving) {
-                    Surface {
-                        FullScreenProgress()
-                    }
-                    return
-                }
-
+        AddItemUi(
+            state = addItemUiState,
+            chooser = {
                 val navigation = LocalNavigationTransaction.current
-
                 CompendiumItemChooser(
                     state = state.availableCompendiumItems,
                     title = stringResource(Str.traits_title_choose_compendium_trait),
@@ -64,33 +47,23 @@ class AddTraitScreen(
                     icon = { Resources.Drawable.Trait },
                     onSelect = {
                         if (it.specifications.isEmpty()) {
-                            saving = true
-                            coroutineScope.launch(Dispatchers.IO) {
-                                screenModel.saveNewTrait(it.id, emptyMap())
-                                navigation.goBack()
-                            }
+                            addItemUiState.saveItem(Trait.fromCompendium(it, emptyMap()))
                         } else {
-                            setStep(Step.FillingInTimesSpecifications(it))
+                            addItemUiState.openSpecificationScreen(it)
                         }
                     },
                     emptyUiIcon = Resources.Drawable.Trait,
                 )
-            }
-            is Step.FillingInTimesSpecifications ->
+            },
+            specification = { compendiumTrait ->
                 TraitSpecificationsForm(
                     existingTrait = null,
-                    onSave = { screenModel.saveNewTrait(step.compendiumTrait.id, it) },
-                    onDismissRequest = { setStep(Step.ChoosingCompendiumTrait) },
-                    defaultSpecifications = step.compendiumTrait.specifications.associateWith { "" },
+                    onSave = { screenModel.saveNewTrait(Trait.fromCompendium(compendiumTrait, it)) },
+                    onDismissRequest = addItemUiState::openChoosingScreen,
+                    defaultSpecifications = compendiumTrait.specifications.associateWith { "" },
                 )
-        }
-    }
-
-    private sealed class Step : Parcelable {
-        @Parcelize
-        class FillingInTimesSpecifications(val compendiumTrait: Trait) : Step()
-
-        @Parcelize
-        object ChoosingCompendiumTrait : Step()
+            },
+            nonCompendiumItemForm = { error("There is no support for non-compendium Trait") },
+        )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/traits/add/AddTraitScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/traits/add/AddTraitScreenModel.kt
@@ -1,12 +1,8 @@
 package cz.frantisekmasa.wfrp_master.common.character.traits.add
 
 import cafe.adriel.voyager.core.model.ScreenModel
-import com.benasher44.uuid.Uuid
-import com.benasher44.uuid.uuid4
 import cz.frantisekmasa.wfrp_master.common.character.effects.EffectManager
 import cz.frantisekmasa.wfrp_master.common.character.items.AvailableCompendiumItemsFactory
-import cz.frantisekmasa.wfrp_master.common.character.traits.dialog.TraitSpecificationsForm
-import cz.frantisekmasa.wfrp_master.common.compendium.domain.exceptions.CompendiumItemNotFound
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterItemRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.Compendium
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
@@ -19,7 +15,7 @@ import cz.frantisekmasa.wfrp_master.common.compendium.domain.Trait as Compendium
 class AddTraitScreenModel(
     private val characterId: CharacterId,
     private val traits: CharacterItemRepository<Trait>,
-    private val compendium: Compendium<CompendiumTrait>,
+    compendium: Compendium<CompendiumTrait>,
     private val effectManager: EffectManager,
     private val firestore: Firestore,
     private val parties: PartyRepository,
@@ -31,36 +27,16 @@ class AddTraitScreenModel(
         filterCharacterItems = traits.findAllForCharacter(characterId),
     ).map { AddTraitScreenState(availableCompendiumItems = it) }
 
-    suspend fun saveNewTrait(
-        compendiumTraitId: Uuid,
-        specificationValues: Map<String, String>,
-    ): TraitSpecificationsForm.SavingResult {
-        val compendiumTrait = try {
-            compendium.getItem(
-                partyId = characterId.partyId,
-                itemId = compendiumTraitId,
-            )
-        } catch (e: CompendiumItemNotFound) {
-            return TraitSpecificationsForm.SavingResult.COMPENDIUM_ITEM_WAS_REMOVED
-        }
-
+    suspend fun saveNewTrait(trait: Trait) {
         firestore.runTransaction { transaction ->
             effectManager.saveItem(
                 transaction,
                 parties.get(characterId.partyId),
                 characterId,
                 repository = traits,
-                item = Trait(
-                    id = uuid4(),
-                    compendiumId = compendiumTrait.id,
-                    name = compendiumTrait.name,
-                    description = compendiumTrait.description,
-                    specificationValues = specificationValues.toMap(),
-                ),
+                item = trait,
                 previousItemVersion = null,
             )
         }
-
-        return TraitSpecificationsForm.SavingResult.SUCCESS
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/traits/dialog/TraitSpecificationsForm.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/traits/dialog/TraitSpecificationsForm.kt
@@ -13,14 +13,13 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.forms.HydratedFormData
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.InputValue
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.Rules
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.TextInput
-import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
 import dev.icerock.moko.resources.compose.stringResource
 
 @Composable
 internal fun TraitSpecificationsForm(
     defaultSpecifications: Map<String, String>,
     existingTrait: Trait?,
-    onSave: suspend (Map<String, String>) -> TraitSpecificationsForm.SavingResult,
+    onSave: suspend (Map<String, String>) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
     val specifications = remember(defaultSpecifications.keys) {
@@ -34,9 +33,6 @@ internal fun TraitSpecificationsForm(
         }
     )
 
-    val snackbarHolder = LocalPersistentSnackbarHolder.current
-    val messageCompendiumTraitRemoved = stringResource(Str.traits_messages_compendium_trait_removed)
-
     FormDialog(
         title = stringResource(
             if (existingTrait != null)
@@ -45,15 +41,7 @@ internal fun TraitSpecificationsForm(
         ),
         formData = formData,
         onDismissRequest = onDismissRequest,
-        onSave = {
-            when (onSave(formData.inputValues.mapValues { it.value.value })) {
-                TraitSpecificationsForm.SavingResult.SUCCESS -> {}
-                TraitSpecificationsForm.SavingResult.COMPENDIUM_ITEM_WAS_REMOVED -> {
-                    snackbarHolder.showSnackbar(messageCompendiumTraitRemoved)
-                }
-            }
-            onDismissRequest()
-        }
+        onSave = { onSave(formData.inputValues.mapValues { it.value.value }) },
     ) { validate ->
         formData.inputValues.forEach { (specificationName, state) ->
             key(specificationName) {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/trappings/TrappingFromCompendiumForm.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/trappings/TrappingFromCompendiumForm.kt
@@ -72,6 +72,7 @@ fun TrappingFromCompendiumForm(
                                     flawValues.value,
                                     max(quantityField.toInt(), 1),
                                 )
+                                onDismissRequest()
                             }
                         },
                         enabled = !saving,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/trappings/add/AddTrappingScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/trappings/add/AddTrappingScreen.kt
@@ -1,17 +1,16 @@
 package cz.frantisekmasa.wfrp_master.common.character.trappings.add
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import cafe.adriel.voyager.core.screen.Screen
 import com.benasher44.uuid.Uuid
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.CompendiumItemChooser
+import cz.frantisekmasa.wfrp_master.common.character.items.AddItemUi
+import cz.frantisekmasa.wfrp_master.common.character.items.rememberAddItemUiState
 import cz.frantisekmasa.wfrp_master.common.character.trappings.CharacterTrappingDetailScreen
 import cz.frantisekmasa.wfrp_master.common.character.trappings.NonCompendiumTrappingForm
 import cz.frantisekmasa.wfrp_master.common.character.trappings.TrappingFromCompendiumForm
 import cz.frantisekmasa.wfrp_master.common.character.trappings.trappingIcon
-import cz.frantisekmasa.wfrp_master.common.compendium.domain.Trapping
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.trappings.InventoryItem
 import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
@@ -19,9 +18,6 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
 import cz.frantisekmasa.wfrp_master.common.core.ui.navigation.LocalNavigationTransaction
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
-import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
-import dev.icerock.moko.parcelize.Parcelable
-import dev.icerock.moko.parcelize.Parcelize
 import dev.icerock.moko.resources.compose.stringResource
 
 class AddTrappingScreen(
@@ -34,78 +30,62 @@ class AddTrappingScreen(
         val screenModel: AddTrappingScreenModel = rememberScreenModel(arg = characterId)
         val state = screenModel.state.collectWithLifecycle(null).value
 
-        val (step, setStep) = rememberSaveable { mutableStateOf<Step>(Step.ChoosingCompendiumTrapping) }
-
         if (state == null) {
             FullScreenProgress()
             return
         }
 
-        val snackbarHolder = LocalPersistentSnackbarHolder.current
-        val successMessage = stringResource(Str.common_ui_item_added)
+        val addItemUiState = rememberAddItemUiState(
+            saver = screenModel::saveTrapping,
+            detailScreenFactory = { CharacterTrappingDetailScreen(characterId, it.id) },
+        )
 
-        when (step) {
-            Step.ChoosingCompendiumTrapping -> {
+        AddItemUi(
+            state = addItemUiState,
+            chooser = {
                 val navigation = LocalNavigationTransaction.current
-
                 CompendiumItemChooser(
                     state = state.availableCompendiumItems,
                     title = stringResource(Str.trappings_title_choose_compendium_trapping),
                     onDismissRequest = navigation::goBack,
                     icon = { trappingIcon(it.trappingType) },
-                    onSelect = { setStep(Step.FillingInDetails(it)) },
-                    onCustomItemRequest = { setStep(Step.FillingInCustomTrapping) },
+                    onSelect = addItemUiState::openSpecificationScreen,
+                    onCustomItemRequest = addItemUiState::openNonCompendiumItemForm,
                     customItemButtonText = stringResource(Str.trappings_button_add_non_compendium),
                     emptyUiIcon = Resources.Drawable.TrappingContainer,
                 )
-            }
-
-            Step.FillingInCustomTrapping -> NonCompendiumTrappingForm(
-                existingItem = null,
-                onSaveRequest = {
-                    screenModel.saveTrapping(it)
-                    snackbarHolder.showSnackbar(successMessage)
-                },
-                onDismissRequest = {},
-                defaultContainerId = null,
-            )
-
-            is Step.FillingInDetails -> {
-                val navigation = LocalNavigationTransaction.current
+            },
+            specification = { compendiumTrapping ->
                 TrappingFromCompendiumForm(
-                    itemName = step.compendiumItem.name,
+                    itemName = compendiumTrapping.name,
                     itemQualities = emptySet(),
                     itemFlaws = emptySet(),
                     quantity = 1,
                     onSaveRequest = { itemQualities, itemFlaws, quantity ->
                         val item = InventoryItem.fromCompendium(
-                            step.compendiumItem,
+                            compendiumTrapping,
                             itemQualities,
                             itemFlaws,
                             quantity,
                         )
 
-                        screenModel.saveTrapping(
+                        addItemUiState.saveItem(
                             if (containerId != null)
                                 item.addToContainer(containerId)
                             else item
                         )
-
-                        snackbarHolder.showSnackbar(successMessage)
-                        navigation.replace(CharacterTrappingDetailScreen(characterId, item.id))
                     },
-                    onDismissRequest = { setStep(Step.ChoosingCompendiumTrapping) },
+                    onDismissRequest = addItemUiState::openChoosingScreen,
+                )
+            },
+            nonCompendiumItemForm = {
+                NonCompendiumTrappingForm(
+                    existingItem = null,
+                    onSaveRequest = addItemUiState::saveItem,
+                    onDismissRequest = addItemUiState::openChoosingScreen,
+                    defaultContainerId = null,
                 )
             }
-        }
-    }
-
-    private sealed class Step : Parcelable {
-        @Parcelize
-        object ChoosingCompendiumTrapping : Step()
-        @Parcelize
-        object FillingInCustomTrapping : Step()
-        @Parcelize
-        data class FillingInDetails(val compendiumItem: Trapping) : Step()
+        )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/talents/Talent.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/talents/Talent.kt
@@ -3,6 +3,7 @@ package cz.frantisekmasa.wfrp_master.common.core.domain.talents
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import com.benasher44.uuid.Uuid
+import com.benasher44.uuid.uuid4
 import cz.frantisekmasa.wfrp_master.common.character.effects.AdditionalEncumbrance
 import cz.frantisekmasa.wfrp_master.common.character.effects.CharacterEffect
 import cz.frantisekmasa.wfrp_master.common.character.effects.CharacteristicChange
@@ -60,5 +61,16 @@ data class Talent(
     companion object {
         const val NAME_MAX_LENGTH = 50
         const val DESCRIPTION_MAX_LENGTH = 1500
+
+        fun fromCompendium(compendiumTalent: CompendiumTalent, timesTaken: Int): Talent {
+            return Talent(
+                id = uuid4(),
+                compendiumId = compendiumTalent.id,
+                name = compendiumTalent.name,
+                tests = compendiumTalent.tests,
+                description = compendiumTalent.description,
+                taken = timesTaken,
+            )
+        }
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/traits/Trait.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/traits/Trait.kt
@@ -3,6 +3,7 @@ package cz.frantisekmasa.wfrp_master.common.core.domain.traits
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import com.benasher44.uuid.Uuid
+import com.benasher44.uuid.uuid4
 import cz.frantisekmasa.wfrp_master.common.character.effects.CharacterEffect
 import cz.frantisekmasa.wfrp_master.common.character.effects.CharacteristicChange
 import cz.frantisekmasa.wfrp_master.common.character.effects.ConstructWoundsModification
@@ -71,6 +72,21 @@ data class Trait(
         }
         require(description.length <= CompendiumTrait.DESCRIPTION_MAX_LENGTH) {
             "Maximum allowed description length is ${CompendiumTrait.DESCRIPTION_MAX_LENGTH}"
+        }
+    }
+
+    companion object {
+        fun fromCompendium(
+            compendiumTrait: CompendiumTrait,
+            specificationValues: Map<String, String>,
+        ): Trait {
+            return Trait(
+                id = uuid4(),
+                compendiumId = compendiumTrait.id,
+                name = compendiumTrait.name,
+                description = compendiumTrait.description,
+                specificationValues = specificationValues.toMap(),
+            )
         }
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/scaffolding/PersistentSnackbarHolder.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/scaffolding/PersistentSnackbarHolder.kt
@@ -2,6 +2,7 @@ package cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding
 
 import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.SnackbarResult
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.staticCompositionLocalOf
 import kotlinx.coroutines.CoroutineScope
@@ -18,9 +19,26 @@ class PersistentSnackbarHolder(
     private val snackbarHostState: SnackbarHostState,
 ) {
 
-    fun showSnackbar(message: String, duration: SnackbarDuration = SnackbarDuration.Short) {
+    fun showSnackbar(
+        message: String,
+        duration: SnackbarDuration = SnackbarDuration.Short,
+        action: SnackbarAction? = null
+    ) {
         coroutineScope.launch(Dispatchers.Default) {
-            snackbarHostState.showSnackbar(message = message, duration = duration)
+            val result = snackbarHostState.showSnackbar(
+                message = message,
+                duration = duration,
+                actionLabel = action?.label,
+            )
+
+            if (result == SnackbarResult.ActionPerformed && action != null) {
+                action.onPerform()
+            }
         }
     }
+
+    data class SnackbarAction(
+        val label: String,
+        val onPerform: () -> Unit,
+    )
 }

--- a/common/src/commonMain/resources/MR/base/strings.xml
+++ b/common/src/commonMain/resources/MR/base/strings.xml
@@ -499,7 +499,6 @@
     <string name="skills_messages_add_basic_skills_explanation">All Basic Skills (%d) will be added without any Advances.</string>
     <string name="skills_messages_basic_skills_added">All Basic Skills were added.</string>
     <string name="skills_messages_character_has_no_skills">Character doesn\'t have any skills.</string>
-    <string name="skills_messages_compendium_skill_removed">Compendium skill was removed in the meantime</string>
     <string name="skills_messages_no_basic_skills_to_add">There are no additional Basic Skills to add from Compendium.</string>
     <string name="skills_messages_no_skills_in_compendium">No skills</string>
     <string name="skills_messages_no_skills_in_compendium_subtext">There are no skills in your compendium yet.</string>
@@ -563,7 +562,6 @@
     <string name="talents_label_name">Name</string>
     <string name="talents_label_tests">Tests</string>
     <string name="talents_label_times_taken">Times taken</string>
-    <string name="talents_messages_compendium_talent_removed">Compendium talent was removed in the meantime</string>
     <string name="talents_messages_no_talents_in_compendium">No talents</string>
     <string name="talents_messages_no_talents_in_compendium_subtext">There are no talents in your compendium yet.</string>
     <string name="talents_tip_hardy_talent_checkbox">Hardy checkbox will be removed in the future.\nAdd Talent called "Hardy" and delete manual Max. Wounds value instead.</string>
@@ -603,7 +601,6 @@
     <string name="traits_label_description">Description</string>
     <string name="traits_label_name">Name</string>
     <string name="traits_label_specifications">Specifications</string>
-    <string name="traits_messages_compendium_trait_removed">Compendium trait was removed in the meantime</string>
     <string name="traits_messages_no_traits_in_compendium">No traits</string>
     <string name="traits_messages_no_traits_in_compendium_subtext">There are no traits in your compendium yet.</string>
     <string name="traits_specifications_helper">Comma separated list of Specifications</string>

--- a/common/src/commonMain/resources/MR/es/strings.xml
+++ b/common/src/commonMain/resources/MR/es/strings.xml
@@ -234,7 +234,6 @@
     <string name="common_ui_item_added">Se ha añadido el objeto.</string>
     <string name="trappings_label_encumbrance_total">Impedimenta (total)</string>
     <string name="journal_title_edit_entry">Editar Entrada del Diario</string>
-    <string name="traits_messages_compendium_trait_removed">El rasgo del Compendio se ha eliminado mientras tanto</string>
     <string name="character_size_large">Grande</string>
     <string name="trappings_expression_constants_damage_special">Especial</string>
     <string name="character_effect_sturdy">robusto</string>
@@ -504,7 +503,6 @@
     <string name="spells_label_name">Nombre</string>
     <string name="trappings_flaws_ugly">Feo</string>
     <string name="points_label_spent_experience">PX gastados anteriormente</string>
-    <string name="talents_messages_compendium_talent_removed">El talento del Compendio se ha eliminado mientras tanto</string>
     <string name="armour_types_soft_leather">De Cuero Blando</string>
     <string name="weapons_ranged_groups_throwing">Arrojadizas</string>
     <string name="weapons_label_flaws">Defectos de arma</string>
@@ -548,7 +546,6 @@
     <string name="common_ui_icon_toggle_fab_menu">Desplegar menú</string>
     <string name="authentication_button_log_out">Desconectar</string>
     <string name="parties_button_share_link">Compartir enlace</string>
-    <string name="skills_messages_compendium_skill_removed">La habilidad del Compendio se ha eliminado mientras tanto</string>
     <string name="authentication_messages_signed_in_as">Estás registrado como</string>
     <string name="compendium_button_import">Importar</string>
     <string name="changelog_github_button">Ver el resto en GitHub</string>

--- a/common/src/commonMain/resources/MR/fr/strings.xml
+++ b/common/src/commonMain/resources/MR/fr/strings.xml
@@ -143,7 +143,6 @@
     <string name="spells_title_choose_compendium_spell">Choisir le sort du Compendium…</string>
     <string name="talents_label_description">Description (optionnel)</string>
     <string name="spells_title_edit">Éditer le sort</string>
-    <string name="talents_messages_compendium_talent_removed">Le talent a été supprimée du Compendium entre-temps</string>
     <string name="tests_cannot_test_against_unknown_advanced_skill">Le personnage ne peut pas faire de test contre une compétence avancée qu\'il ne connaît pas.</string>
     <string name="talents_title_choose_compendium_talent">Choisir le talent du Compendium…</string>
     <string name="tests_critical">Critique</string>
@@ -239,8 +238,6 @@
     <string name="trappings_title_choose_compendium_trapping">Choisir l\'objet du Compendium…</string>
     <string name="careers_button_clear_select_box">Effacer la boîte de sélection de la carrière</string>
     <string name="traits_specifications_helper">Liste de spécifications séparées par des virgules</string>
-    <string name="traits_messages_compendium_trait_removed">Le trait a été supprimée du Compendium entre-temps</string>
-    <string name="skills_messages_compendium_skill_removed">La compétence a été supprimée du Compendium entre-temps</string>
     <string name="character_tab_conditions">Conditions</string>
     <string name="messages_search_not_found_subtext">Envisagez de modifier l\'expression de recherche.</string>
     <string name="trappings_types_container">Conteneurs</string>

--- a/common/src/commonMain/resources/MR/it/strings.xml
+++ b/common/src/commonMain/resources/MR/it/strings.xml
@@ -385,7 +385,6 @@
     <string name="skills_messages_add_basic_skills_explanation">Tutte le Abilità Base (%d) verrà aggiunto senza Avanzamenti.</string>
     <string name="skills_messages_basic_skills_added">Sono state aggiunte tutte le Abilità Base.</string>
     <string name="skills_messages_character_has_no_skills">Il Personaggio non ha Abilità.</string>
-    <string name="skills_messages_compendium_skill_removed">Abilità rimossa dal Compendio</string>
     <string name="skills_messages_no_basic_skills_to_add">Non ci sono Abilità Base da aggiungere dal Compendio.</string>
     <string name="skills_messages_no_skills_in_compendium">Nessuna Abilità</string>
     <string name="skills_messages_no_skills_in_compendium_subtext">Non ci sono ancora Abilità nel Compendio.</string>
@@ -449,7 +448,6 @@
     <string name="talents_label_name">Nome</string>
     <string name="talents_label_tests">Prove</string>
     <string name="talents_label_times_taken">Grado</string>
-    <string name="talents_messages_compendium_talent_removed">Il Talento è stato rimosso dal Compendio</string>
     <string name="talents_messages_no_talents_in_compendium">Nessun Talento</string>
     <string name="talents_messages_no_talents_in_compendium_subtext">Non ci sono ancora Talenti nel tuo Compendio.</string>
     <string name="talents_tip_hardy_talent_checkbox">Il check Gagliardo verrà rimosso in futuro.\nAggiungi il talento chiamato "Gagliardo" ed elimina il numero MAX manuale. Le Ferite danno invece valore.</string>
@@ -490,7 +488,6 @@
     <string name="traits_label_description">Descrizione</string>
     <string name="traits_label_name">Nome</string>
     <string name="traits_label_specifications">Specifiche</string>
-    <string name="traits_messages_compendium_trait_removed">Il Tratto è stato rimosso del Compendio</string>
     <string name="traits_messages_no_traits_in_compendium">Nessun Tratto</string>
     <string name="traits_messages_no_traits_in_compendium_subtext">Non ci sono ancora Tratti nel tuo Compendio.</string>
     <string name="traits_specifications_helper">Lista specifiche separate da una virgola</string>


### PR DESCRIPTION
Before, addding new Trapping navigated user to Trapping detail, adding Spell did nothing, etc.

Now when any type of item is added, user is navigated back to Compendium chooser and new "Item was added" snackbar is shown with button that leads user directly to item detail.