### PR TITLE
Trim all text field values and make TextInput API safer

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/trappings/NonCompendiumTrappingForm.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/trappings/NonCompendiumTrappingForm.kt
@@ -456,10 +456,10 @@ private class TrappingTypeFormData(
     override fun toValue(): TrappingType? = when (type.value) {
         TrappingTypeOption.AMMUNITION -> TrappingType.Ammunition(
             weaponGroups = ammunitionWeaponGroups.value,
-            range = AmmunitionRangeExpression(ammunitionRange.normalizedValue),
+            range = AmmunitionRangeExpression(ammunitionRange.value),
             qualities = weaponQualities.toMap(),
             flaws = weaponFlaws.toMap(),
-            damage = DamageExpression(damage.normalizedValue),
+            damage = DamageExpression(damage.value),
         )
         TrappingTypeOption.ARMOUR -> TrappingType.Armour(
             locations = armourLocations.value,
@@ -483,7 +483,7 @@ private class TrappingTypeFormData(
         TrappingTypeOption.MELEE_WEAPON -> TrappingType.MeleeWeapon(
             group = meleeWeaponGroup.value,
             reach = weaponReach.value,
-            damage = DamageExpression(damage.normalizedValue),
+            damage = DamageExpression(damage.value),
             qualities = weaponQualities.toMap(),
             flaws = weaponFlaws.toMap(),
             equipped = weaponEquipped.value,
@@ -491,8 +491,8 @@ private class TrappingTypeFormData(
         TrappingTypeOption.PROSTHETIC -> TrappingType.Prosthetic(worn = worn.value)
         TrappingTypeOption.RANGED_WEAPON -> TrappingType.RangedWeapon(
             group = rangedWeaponGroup.value,
-            range = WeaponRangeExpression(weaponRange.normalizedValue),
-            damage = DamageExpression(damage.normalizedValue),
+            range = WeaponRangeExpression(weaponRange.value),
+            damage = DamageExpression(damage.value),
             qualities = weaponQualities.toMap(),
             flaws = weaponFlaws.toMap(),
             equipped = weaponEquipped.value,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/journal/JournalEntryDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/journal/JournalEntryDialog.kt
@@ -105,8 +105,8 @@ private data class JournalEntryFormData(
             .split(JournalEntry.PARENT_SEPARATOR)
             .filter { it.isNotBlank() }
             .map { it.trim() },
-        text = text.normalizedValue,
-        gmText = gmText.normalizedValue,
+        text = text.value,
+        gmText = gmText.value,
         isPinned = isPinned,
         isVisibleToPlayers = isVisibleToPlayers,
     )

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trapping/TrappingDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/compendium/trapping/TrappingDialog.kt
@@ -505,7 +505,7 @@ private class TrappingTypeFormData(
     override fun toValue(): TrappingType? = when (type.value) {
         TrappingTypeOption.AMMUNITION -> TrappingType.Ammunition(
             weaponGroups = ammunitionWeaponGroups.value,
-            range = AmmunitionRangeExpression(ammunitionRange.normalizedValue),
+            range = AmmunitionRangeExpression(ammunitionRange.value),
             qualities = weaponQualities.toMap(),
             flaws = weaponFlaws.toMap(),
             damage = DamageExpression(damage.value.trim()),
@@ -528,15 +528,15 @@ private class TrappingTypeFormData(
         TrappingTypeOption.MELEE_WEAPON -> TrappingType.MeleeWeapon(
             group = meleeWeaponGroup.value,
             reach = weaponReach.value,
-            damage = DamageExpression(damage.normalizedValue),
+            damage = DamageExpression(damage.value),
             qualities = weaponQualities.toMap(),
             flaws = weaponFlaws.toMap(),
         )
         TrappingTypeOption.PROSTHETIC -> TrappingType.Prosthetic
         TrappingTypeOption.RANGED_WEAPON -> TrappingType.RangedWeapon(
             group = rangedWeaponGroup.value,
-            range = WeaponRangeExpression(weaponRange.normalizedValue),
-            damage = DamageExpression(damage.normalizedValue),
+            range = WeaponRangeExpression(weaponRange.value),
+            damage = DamageExpression(damage.value),
             qualities = weaponQualities.toMap(),
             flaws = weaponFlaws.toMap(),
         )

--- a/desktop/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/desktop/auth/ResetPasswordDialog.kt
+++ b/desktop/src/jvmMain/kotlin/cz/frantisekmasa/wfrp_master/desktop/auth/ResetPasswordDialog.kt
@@ -79,7 +79,7 @@ fun ResetPasswordDialog(
                         processing = true
                         coroutineScope.launchLogged(Dispatchers.IO) {
                             try {
-                                when (auth.resetPassword(email.normalizedValue)) {
+                                when (auth.resetPassword(email.value)) {
                                     PasswordResetResult.Success -> {
                                         snackbarHolder.showSnackbar(
                                             messageEmailSent,


### PR DESCRIPTION
Closes https://github.com/fmasa/wfrp-master/issues/247

This PR unifies the way  `TextInput` values are sanitized. Previously `InputValue.value` would contain raw text field value and `InputValue.normalizedValue` would contain normalized value (whitespaces trimmed by default). This made it error-prone, so I renamed `value` to `rawTextFieldValue` and added annotation that requires opt-in (effectively the compilation will fail on accidental use) and renamed `normalizedValue` to `value`. This means that all text fields are now automatically trimmed before saving (which was always the goal).