### PR TITLE
Character duplication using cloud functions

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/DependencyInjection.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/DependencyInjection.kt
@@ -372,13 +372,6 @@ val appModule = DI.Module("Common") {
             partyId,
             instance(),
             instance(),
-            instance(),
-            instance(),
-            instance(),
-            instance(),
-            instance(),
-            instance(),
-            instance(),
         )
     }
     bindFactory { partyId: PartyId ->

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/Character.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/Character.kt
@@ -2,7 +2,6 @@ package cz.frantisekmasa.wfrp_master.common.core.domain.character
 
 import androidx.compose.runtime.Immutable
 import com.benasher44.uuid.Uuid
-import com.benasher44.uuid.uuid4
 import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
 import cz.frantisekmasa.wfrp_master.common.core.domain.Ambitions
@@ -10,7 +9,6 @@ import cz.frantisekmasa.wfrp_master.common.core.domain.Money
 import cz.frantisekmasa.wfrp_master.common.core.domain.Size
 import cz.frantisekmasa.wfrp_master.common.core.domain.Stats
 import cz.frantisekmasa.wfrp_master.common.core.domain.trappings.Encumbrance
-import cz.frantisekmasa.wfrp_master.common.core.utils.duplicateName
 import cz.frantisekmasa.wfrp_master.common.encounters.domain.Wounds
 import dev.icerock.moko.parcelize.Parcelable
 import dev.icerock.moko.parcelize.Parcelize
@@ -238,11 +236,6 @@ data class Character(
     fun updateAmbitions(ambitions: Ambitions) = copy(ambitions = ambitions)
 
     fun updateConditions(newConditions: CurrentConditions) = copy(conditions = newConditions)
-
-    fun duplicate() = copy(
-        id = uuid4().toString(),
-        name = duplicateName(name),
-    )
 
     fun archive() = copy(
         isArchived = true,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/npcs/NpcsScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/npcs/NpcsScreen.kt
@@ -36,7 +36,9 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.EmptyUI
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.ItemIcon
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.SearchableList
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
 import dev.icerock.moko.resources.compose.stringResource
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -116,6 +118,9 @@ class NpcsScreen(
             }
         ) { npc ->
             Column {
+                val unknownErrorMessage = stringResource(Str.messages_error_unknown)
+                val snackbarHolder = LocalPersistentSnackbarHolder.current
+
                 WithContextMenu(
                     onClick = {
                         navigation.navigate(CharacterDetailScreen(CharacterId(partyId, npc.id)))
@@ -126,6 +131,9 @@ class NpcsScreen(
                                 processing = true
                                 try {
                                     screenModel.duplicate(npc)
+                                } catch (e: Exception) {
+                                    Napier.e("Failed to duplicate NPC", e)
+                                    snackbarHolder.showSnackbar(unknownErrorMessage)
                                 } finally {
                                     processing = false
                                 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/npcs/NpcsScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/npcs/NpcsScreenModel.kt
@@ -2,35 +2,17 @@ package cz.frantisekmasa.wfrp_master.common.npcs
 
 import cafe.adriel.voyager.core.model.ScreenModel
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
-import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterItem
-import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterItemRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterRepository
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterType
-import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
-import cz.frantisekmasa.wfrp_master.common.core.domain.religion.BlessingRepository
-import cz.frantisekmasa.wfrp_master.common.core.domain.religion.MiracleRepository
-import cz.frantisekmasa.wfrp_master.common.core.domain.skills.SkillRepository
-import cz.frantisekmasa.wfrp_master.common.core.domain.spells.SpellRepository
-import cz.frantisekmasa.wfrp_master.common.core.domain.talents.TalentRepository
-import cz.frantisekmasa.wfrp_master.common.core.domain.traits.TraitRepository
-import cz.frantisekmasa.wfrp_master.common.core.domain.trappings.InventoryItemRepository
-import cz.frantisekmasa.wfrp_master.common.firebase.firestore.Firestore
-import cz.frantisekmasa.wfrp_master.common.firebase.firestore.Transaction
+import cz.frantisekmasa.wfrp_master.common.core.utils.duplicateName
+import cz.frantisekmasa.wfrp_master.common.firebase.functions.CloudFunctions
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 
 class NpcsScreenModel(
     private val partyId: PartyId,
+    private val functions: CloudFunctions,
     private val characters: CharacterRepository,
-    private val skills: SkillRepository,
-    private val talents: TalentRepository,
-    private val traits: TraitRepository,
-    private val spells: SpellRepository,
-    private val blessings: BlessingRepository,
-    private val miracles: MiracleRepository,
-    private val trappings: InventoryItemRepository,
-    private val firestore: Firestore,
 ) : ScreenModel {
 
     val npcs: Flow<List<Character>> = characters.inParty(partyId, CharacterType.NPC)
@@ -40,33 +22,13 @@ class NpcsScreenModel(
     }
 
     suspend fun duplicate(npc: Character) {
-        firestore.runTransaction { transaction ->
-            val newNpc = npc.duplicate()
-            val existingCharacterId = CharacterId(partyId, npc.id)
-            val newCharacterId = CharacterId(partyId, newNpc.id)
-
-            copyItems(transaction, skills, existingCharacterId, newCharacterId)
-            copyItems(transaction, talents, existingCharacterId, newCharacterId)
-            copyItems(transaction, traits, existingCharacterId, newCharacterId)
-            copyItems(transaction, spells, existingCharacterId, newCharacterId)
-            copyItems(transaction, blessings, existingCharacterId, newCharacterId)
-            copyItems(transaction, miracles, existingCharacterId, newCharacterId)
-            copyItems(transaction, trappings, existingCharacterId, newCharacterId)
-
-            characters.save(transaction, partyId, newNpc)
-        }
-    }
-
-    private suspend fun <T : CharacterItem<T, *>> copyItems(
-        transaction: Transaction,
-        repository: CharacterItemRepository<T>,
-        existingCharacterId: CharacterId,
-        newCharacterId: CharacterId,
-    ) {
-        repository.findAllForCharacter(existingCharacterId)
-            .first()
-            .forEach { item ->
-                repository.save(transaction, newCharacterId, item)
-            }
+        functions.getHttpsCallable("duplicateCharacter")
+            .call(
+                mapOf(
+                    "partyId" to partyId.toString(),
+                    "characterId" to npc.id,
+                    "newName" to duplicateName(npc.name)
+                )
+            )
     }
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -398,6 +398,11 @@
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
       "integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg=="
     },
+    "@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2299,6 +2304,13 @@
         "node-fetch": "^2.6.1",
         "stream-events": "^1.0.5",
         "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "tmp": {
@@ -2425,9 +2437,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "vary": {
       "version": "1.1.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,13 +17,15 @@
     "@google-cloud/storage": "^5.14.4",
     "@types/sharp": "^0.29.2",
     "@types/tmp": "^0.2.1",
+    "@types/uuid": "^9.0.8",
     "fast-crc32c": "^2.0.0",
     "firebase-admin": "^9.12.0",
     "firebase-functions": "^3.15.7",
     "fp-ts": "^2.11.4",
     "io-ts": "^2.2.16",
     "sharp": "^0.29.1",
-    "tmp-promise": "^3.0.2"
+    "tmp-promise": "^3.0.2",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0",

--- a/functions/src/avatar.ts
+++ b/functions/src/avatar.ts
@@ -1,0 +1,24 @@
+import {Bucket, CopyResponse, UploadResponse} from "@google-cloud/storage";
+
+export const generateAvatarUrl = async (response: UploadResponse|CopyResponse, bucket: Bucket): Promise<string> => {
+    if ("FIREBASE_STORAGE_EMULATOR_HOST" in process.env) {
+        const [metadata] = await response[0].getMetadata();
+
+        return metadata.mediaLink;
+    }
+
+    return "https://firebasestorage.googleapis.com/v0/b/"
+        + bucket.name
+        + "/o/"
+        + encodeURIComponent(response[0].name)
+        + "?alt=media"
+        + "&v="
+        + (+new Date());
+}
+
+export const getAvatarPath = (partyId: string, characterId: string): string => `images/parties/${partyId}/characters/${characterId}.webp`;
+
+export const METADATA = {
+    contentType: "image/webp",
+    cacheControl: `max-age=${365 * 24 * 60 * 60}`,
+};

--- a/functions/src/characterChange.ts
+++ b/functions/src/characterChange.ts
@@ -1,0 +1,61 @@
+import * as t from "io-ts";
+import {isLeft} from "fp-ts/Either";
+import * as functions from "firebase-functions";
+import {hasAccessToCharacter} from "./acl";
+import {firestore} from "firebase-admin";
+
+const RequiredFields = t.type({
+    partyId: t.string,
+    characterId: t.string,
+})
+
+type RequiredProps = (typeof RequiredFields)['props'];
+type RequestBody<T> = T extends t.TypeC<any> ? (T['props'] extends RequiredProps ? T : never) : never;
+
+export const characterChange = <T>(
+    requestBodyCodec: RequestBody<T>,
+    handler: (body: t.TypeOf<RequestBody<T>>, character: firestore.DocumentReference) => Promise<any>,
+) => {
+    return functions.https.onCall(async (data, context) => {
+        const body = requestBodyCodec.decode(data);
+
+        if (isLeft(body)) {
+            return {
+                status: "error",
+                error: 400,
+                message: "Invalid request body",
+            };
+        }
+
+        const userId = context.auth?.uid;
+        const {characterId, partyId} = body.right;
+
+        if (userId === undefined) {
+            return {
+                status: "error",
+                error: 401,
+                message: "User is not authorized",
+            };
+        }
+
+        if (!await hasAccessToCharacter(userId, partyId, characterId)) {
+            return {
+                status: "error",
+                error: 403,
+                message: "User does not have access to given character",
+            };
+        }
+
+        const character = firestore().doc(`parties/${partyId}/characters/${characterId}`);
+
+        if (!(await character.get()).exists) {
+            return {
+                status: "error",
+                error: 404,
+                message: "Character does not exist",
+            }
+        }
+
+        return handler(body.right, character);
+    });
+};

--- a/functions/src/functions/changeCharacterAvatar.ts
+++ b/functions/src/functions/changeCharacterAvatar.ts
@@ -2,9 +2,8 @@ import {storage} from 'firebase-admin';
 import {file} from "tmp-promise";
 import * as sharp from "sharp";
 import * as t from "io-ts";
-import {UploadResponse} from "@google-cloud/storage/build/src/bucket";
-import {Bucket} from "@google-cloud/storage";
 import {characterChange} from "../characterChange";
+import {generateAvatarUrl, getAvatarPath, METADATA} from "../avatar";
 
 const imageSize = 500;
 
@@ -30,15 +29,12 @@ export const changeCharacterAvatar = characterChange(RequestBody,async (body, ch
     const response = await bucket.upload(
         tempFile.path,
         {
-            destination: `images/parties/${partyId}/characters/${characterId}.webp`,
-            metadata: {
-                contentType: "image/webp",
-                cacheControl: `max-age=${365 * 24 * 60 * 60}`,
-            },
+            destination: getAvatarPath(partyId, characterId),
+            metadata: METADATA,
         }
     );
 
-    const url = generateAvatarUrl(response, bucket);
+    const url = await generateAvatarUrl(response, bucket);
 
     console.debug(`File url: ${url}`);
 
@@ -70,18 +66,4 @@ const cropToRectangle = async (image: sharp.Sharp): Promise<sharp.Sharp> => {
         width: size,
         height: size,
     })
-}
-
-const generateAvatarUrl = (response: UploadResponse, bucket: Bucket): string => {
-    if ("FIREBASE_STORAGE_EMULATOR_HOST" in process.env) {
-        return response[1].mediaLink;
-    }
-
-    return "https://firebasestorage.googleapis.com/v0/b/"
-        + bucket.name
-        + "/o/"
-        + encodeURIComponent(response[0].name)
-        + "?alt=media"
-        + "&v="
-        + (+new Date());
 }

--- a/functions/src/functions/duplicateCharacter.ts
+++ b/functions/src/functions/duplicateCharacter.ts
@@ -1,0 +1,47 @@
+import {firestore} from 'firebase-admin';
+import * as t from "io-ts";
+import {characterChange} from "../characterChange";
+import { v4 as uuidv4 } from "uuid";
+
+const RequestBody = t.interface({
+    partyId: t.string,
+    characterId: t.string,
+    newName: t.string,
+});
+
+export const duplicateCharacter = characterChange(RequestBody, async (body, character) => {
+    const batch = firestore().batch();
+    const newCharacterId = uuidv4();
+    const newCharacter = character.parent.doc(newCharacterId);
+    const characterData = (await character.get()).data();
+
+    batch.set(
+        newCharacter,
+        {
+            ...characterData,
+            id: newCharacterId,
+            name: body.newName,
+        }
+    )
+
+    const collections = await character.listCollections();
+
+    await Promise.all(
+        collections.map(async (collection) => {
+            await Promise.all(
+                (await collection.listDocuments()).map(async (document) => {
+                    batch.set(
+                        newCharacter.collection(collection.id).doc(document.id),
+                        (await document.get()).data(),
+                    );
+                })
+            );
+        })
+    );
+
+    await batch.commit();
+
+    return {
+        status: "success",
+    };
+})

--- a/functions/src/functions/duplicateCharacter.ts
+++ b/functions/src/functions/duplicateCharacter.ts
@@ -1,7 +1,8 @@
-import {firestore} from 'firebase-admin';
+import {firestore, storage} from 'firebase-admin';
 import * as t from "io-ts";
 import {characterChange} from "../characterChange";
 import { v4 as uuidv4 } from "uuid";
+import {generateAvatarUrl, getAvatarPath, METADATA} from "../avatar";
 
 const RequestBody = t.interface({
     partyId: t.string,
@@ -9,20 +10,26 @@ const RequestBody = t.interface({
     newName: t.string,
 });
 
+type Character = {
+    avatarUrl: string | null;
+}
+
 export const duplicateCharacter = characterChange(RequestBody, async (body, character) => {
     const batch = firestore().batch();
     const newCharacterId = uuidv4();
     const newCharacter = character.parent.doc(newCharacterId);
-    const characterData = (await character.get()).data();
+    const characterData = (await character.get()).data() as Character;
 
-    batch.set(
-        newCharacter,
-        {
-            ...characterData,
-            id: newCharacterId,
-            name: body.newName,
-        }
-    )
+    const newCharacterData =         {
+        ...characterData,
+        id: newCharacterId,
+        name: body.newName,
+        avatarUrl: await copyAvatar(characterData.avatarUrl, body.partyId, body.characterId, newCharacterId),
+    };
+
+    console.log("New character data", newCharacterData);
+
+    batch.set(newCharacter, newCharacterData);
 
     const collections = await character.listCollections();
 
@@ -45,3 +52,34 @@ export const duplicateCharacter = characterChange(RequestBody, async (body, char
         status: "success",
     };
 })
+
+const copyAvatar = async (
+    avatarUrl: string | null,
+    partyId: string,
+    characterId: string,
+    newCharacterId: string,
+): Promise<string | null> => {
+    if (avatarUrl === null) {
+        return null;
+    }
+
+    const bucket = storage().bucket();
+
+    try {
+        const sourceFile = bucket.file(getAvatarPath(partyId, characterId));
+
+        if (!(await sourceFile.exists())[0]) {
+            return null;
+        }
+
+        const copyResponse = await sourceFile.copy(
+            bucket.file(getAvatarPath(partyId, newCharacterId)),
+            {metadata: METADATA}
+        );
+
+        return await generateAvatarUrl(copyResponse, bucket);
+    } catch (e) {
+        console.error(e);
+        return null;
+    }
+}

--- a/functions/src/functions/removeCharacterAvatar.ts
+++ b/functions/src/functions/removeCharacterAvatar.ts
@@ -1,50 +1,20 @@
-import * as functions from "firebase-functions";
-import {isLeft} from "fp-ts/Either";
-import {hasAccessToCharacter} from "../acl";
 import * as t from "io-ts";
-import {firestore, storage} from "firebase-admin";
+import {storage} from "firebase-admin";
+import {characterChange} from "../characterChange";
 
 const RequestBody = t.interface({
     partyId: t.string,
     characterId: t.string,
 });
 
-export const removeCharacterAvatar = functions.https.onCall(async (data, context) => {
-    const body = RequestBody.decode(data);
-
-    if (isLeft(body)) {
-        return {
-            error: 400,
-            message: "Invalid request body",
-        };
-    }
-
-    const userId = context.auth?.uid;
-    const partyId = body.right.partyId;
-    const characterId = body.right.characterId;
-
-    if (userId === undefined) {
-        return {
-            status: "error",
-            error: 401,
-            message: "User is not authorized",
-        };
-    }
-
-    if (!await hasAccessToCharacter(userId, partyId, characterId)) {
-        return {
-            status: "error",
-            error: 403,
-            message: "User does not have access to given character",
-        };
-    }
+export const removeCharacterAvatar = characterChange(RequestBody, async (body, character) => {
+    const {partyId, characterId} = body;
 
     await storage()
         .bucket()
         .deleteFiles({prefix: `images/parties/${partyId}/characters/${characterId}.webp`});
 
-    await firestore().doc(`parties/${partyId}/characters/${characterId}`)
-        .update("avatarUrl", null)
+    await character.update("avatarUrl", null);
 
     return {status: "success"};
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,11 +1,13 @@
 import * as admin from 'firebase-admin';
 import { changeCharacterAvatar } from './functions/changeCharacterAvatar';
 import { removeCharacterAvatar } from './functions/removeCharacterAvatar';
+import { duplicateCharacter } from './functions/duplicateCharacter';
 
 admin.initializeApp();
 
 export {
     changeCharacterAvatar,
     removeCharacterAvatar,
+    duplicateCharacter,
 }
 


### PR DESCRIPTION
Fixes https://github.com/fmasa/wfrp-master/issues/253

Previously the duplication was done on the device, which had two main issues:
- There is a limit for [document reads used in security rules](https://firebase.google.com/docs/firestore/manage-data/transactions#security_rules_limits) (20) - since every compendium character item checks whether the item in compendium exists, this would only work for small NPCs. By moving this to cloud functions, security rules are not used and this is no longer a problem (there is still a limit of 500 writes in a single batch, but I guess this should be enough for vast majority of NPCs)
- The new NPC has the same avatar URL, so if the user changes the original NPC's avatar, the new NPC gets that avatar as well - now it's copied, so this file is not shared anymore.
