### PR TITLE
Let GMs manage NPCs from NPC picker in Encounter

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/DependencyInjection.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/DependencyInjection.kt
@@ -358,6 +358,8 @@ val appModule =
                 instance(),
                 instance(),
                 instance(),
+                instance(),
+                instance(),
             )
         }
         bindFactory { partyId: PartyId ->

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterCreation/CharacterCreationScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterCreation/CharacterCreationScreen.kt
@@ -45,6 +45,7 @@ import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.CharacterDetailScreen
 import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterType
+import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.EncounterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.BackButton
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
@@ -67,6 +68,7 @@ class CharacterCreationScreen(
     val partyId: PartyId,
     val type: CharacterType,
     val userId: UserId?,
+    val encounterId: EncounterId? = null,
 ) : Screen {
     @Composable
     override fun Content() {
@@ -78,7 +80,12 @@ class CharacterCreationScreen(
                 )
             },
         ) {
-            MainContainer(partyId, type, userId)
+            MainContainer(
+                partyId = partyId,
+                type = type,
+                userId = userId,
+                encounterId = encounterId,
+            )
         }
     }
 }
@@ -88,6 +95,7 @@ private fun Screen.MainContainer(
     partyId: PartyId,
     type: CharacterType,
     userId: UserId?,
+    encounterId: EncounterId?,
 ) {
     val screenModel: CharacterCreationScreenModel = rememberScreenModel(arg = partyId)
     val coroutineScope = rememberCoroutineScope()
@@ -118,6 +126,7 @@ private fun Screen.MainContainer(
                     basicInfo,
                     characteristics,
                     points,
+                    encounterId,
                 )
 
             navigation.replace(CharacterDetailScreen(characterId))

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterCreation/CharacterCreationScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/characterCreation/CharacterCreationScreenModel.kt
@@ -10,11 +10,14 @@ import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterReposi
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterType
 import cz.frantisekmasa.wfrp_master.common.core.domain.compendium.Compendium
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
+import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.EncounterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyRepository
 import cz.frantisekmasa.wfrp_master.common.core.logging.Reporter
 import cz.frantisekmasa.wfrp_master.common.core.ui.forms.SelectedCareer
 import cz.frantisekmasa.wfrp_master.common.core.utils.right
+import cz.frantisekmasa.wfrp_master.common.encounters.domain.EncounterRepository
+import dev.gitlive.firebase.firestore.FirebaseFirestore
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -24,8 +27,10 @@ import kotlinx.coroutines.withContext
 class CharacterCreationScreenModel(
     private val partyId: PartyId,
     private val characters: CharacterRepository,
+    private val encounters: EncounterRepository,
     careerCompendium: Compendium<Career>,
     private val userProvider: UserProvider,
+    private val firestore: FirebaseFirestore,
     parties: PartyRepository,
 ) : ScreenModel {
     val careers: Flow<List<Career>> =
@@ -44,6 +49,7 @@ class CharacterCreationScreenModel(
         info: CharacterBasicInfoForm.Data,
         characteristicsData: CharacterCharacteristicsForm.Data,
         points: PointsPoolForm.Data,
+        encounterId: EncounterId?,
     ): CharacterId {
         val characterId = CharacterId(partyId, uuid4().toString())
 
@@ -54,33 +60,45 @@ class CharacterCreationScreenModel(
                 val characteristics = characteristicsData.toValue()
                 val career = info.career.value
 
-                characters.save(
-                    characterId.partyId,
-                    Character(
-                        id = characterId.id,
-                        type = type,
-                        name = info.name.value,
-                        publicName = info.publicName.value.takeIf { it.isNotBlank() },
-                        userId = userId,
-                        career = if (career is SelectedCareer.NonCompendiumCareer) career.careerName else "",
-                        socialClass = if (career is SelectedCareer.NonCompendiumCareer) career.socialClass else "",
-                        status = info.status.value,
-                        race = info.race.value,
-                        characteristicsBase = characteristics.base,
-                        characteristicsAdvances = characteristics.advances,
-                        points = points.toValue(),
-                        psychology = info.psychology.value,
-                        motivation = info.motivation.value,
-                        note = info.note.value,
-                        compendiumCareer = if (career is SelectedCareer.CompendiumCareer) career.value else null,
-                    ).refreshWounds(),
-                )
+                firestore.runTransaction {
+                    characters.save(
+                        characterId.partyId,
+                        Character(
+                            id = characterId.id,
+                            type = type,
+                            name = info.name.value,
+                            publicName = info.publicName.value.takeIf { it.isNotBlank() },
+                            userId = userId,
+                            career = if (career is SelectedCareer.NonCompendiumCareer) career.careerName else "",
+                            socialClass = if (career is SelectedCareer.NonCompendiumCareer) career.socialClass else "",
+                            status = info.status.value,
+                            race = info.race.value,
+                            characteristicsBase = characteristics.base,
+                            characteristicsAdvances = characteristics.advances,
+                            points = points.toValue(),
+                            psychology = info.psychology.value,
+                            motivation = info.motivation.value,
+                            note = info.note.value,
+                            compendiumCareer = if (career is SelectedCareer.CompendiumCareer) career.value else null,
+                        ).refreshWounds(),
+                    )
+
+                    val encounter = encounterId?.let { encounters.find(it) }
+
+                    if (encounter != null) {
+                        encounters.save(
+                            partyId,
+                            encounter.withCharacterCount(characterId.id, 1),
+                        )
+                    }
+                }
 
                 Reporter.recordEvent(
                     "create_character",
                     mapOf(
                         "party_id" to characterId.partyId.toString(),
                         "character_id" to characterId.id,
+                        "encounter_id" to (encounterId?.toString() ?: ""),
                     ),
                 )
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/ChooseNpcDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/ChooseNpcDialog.kt
@@ -1,8 +1,9 @@
 package cz.frantisekmasa.wfrp_master.common.encounters
 
-import androidx.compose.foundation.clickable
-import androidx.compose.material.ListItem
-import androidx.compose.material.Text
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -10,17 +11,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import cz.frantisekmasa.wfrp_master.common.Str
-import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
-import cz.frantisekmasa.wfrp_master.common.core.ui.CharacterAvatar
+import cz.frantisekmasa.wfrp_master.common.characterCreation.CharacterCreationScreen
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterType
 import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.CloseButton
 import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.FullScreenDialog
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
-import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.EmptyUI
-import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.ItemIcon
+import cz.frantisekmasa.wfrp_master.common.core.ui.navigation.LocalNavigationTransaction
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.SearchableList
 import cz.frantisekmasa.wfrp_master.common.encounters.domain.Encounter
+import cz.frantisekmasa.wfrp_master.common.npcs.NpcList
+import cz.frantisekmasa.wfrp_master.common.npcs.NpcsScreenModel
 import dev.icerock.moko.resources.compose.stringResource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -29,10 +30,14 @@ import kotlinx.coroutines.launch
 fun ChooseNpcDialog(
     encounter: Encounter,
     screenModel: EncounterDetailScreenModel,
+    npcsScreenModel: NpcsScreenModel,
     onDismissRequest: () -> Unit,
 ) {
     FullScreenDialog(onDismissRequest) {
         val npcs by screenModel.allNpcsCharacters.collectWithLifecycle(null)
+        val navigation = LocalNavigationTransaction.current
+        val coroutineScope = rememberCoroutineScope()
+
         var saving by remember { mutableStateOf(false) }
         val notUsedNpcs by derivedStateOf {
             if (saving) {
@@ -44,44 +49,37 @@ fun ChooseNpcDialog(
                 ?: SearchableList.Data.Loading
         }
 
-        val coroutineScope = rememberCoroutineScope()
-
-        SearchableList(
-            data = notUsedNpcs,
-            key = { it.id },
-            searchableValue = { it.name },
+        NpcList(
+            title = stringResource(Str.npcs_title_plural),
             navigationIcon = { CloseButton(onDismissRequest) },
-            title = stringResource(Str.npcs_title_add),
-            searchPlaceholder = stringResource(Str.npcs_search_placeholder),
-            emptyUi = {
-                EmptyUI(
-                    text = stringResource(Str.npcs_messages_no_npcs),
-                    icon = Resources.Drawable.Npc,
-                )
-            },
-        ) { item ->
-            ListItem(
-                modifier =
-                    Modifier.clickable(
-                        onClick = {
-                            saving = false
-                            coroutineScope.launch(Dispatchers.IO) {
-                                screenModel.updateEncounter(
-                                    encounter.withCharacterCount(item.id, 1),
-                                )
-                                onDismissRequest()
-                            }
-                        },
-                    ),
-                icon = {
-                    CharacterAvatar(
-                        item.avatarUrl,
-                        fallback = Resources.Drawable.Npc,
-                        size = ItemIcon.Size.Small,
+            data = notUsedNpcs,
+            onClick = { characterId ->
+                saving = false
+                coroutineScope.launch(Dispatchers.IO) {
+                    screenModel.updateEncounter(
+                        encounter.withCharacterCount(characterId.id, 1),
                     )
-                },
-                text = { Text(item.name) },
-            )
-        }
+                    onDismissRequest()
+                }
+            },
+            screenModel = npcsScreenModel,
+            floatingActionButton = {
+                FloatingActionButton(
+                    onClick = {
+                        navigation.navigate(
+                            CharacterCreationScreen(
+                                partyId = screenModel.encounterId.partyId,
+                                type = CharacterType.NPC,
+                                userId = null,
+                                encounterId = screenModel.encounterId,
+                            ),
+                        )
+                        onDismissRequest()
+                    },
+                ) {
+                    Icon(Icons.Rounded.Add, stringResource(Str.npcs_button_add_npc))
+                }
+            },
+        )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/EncounterDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/EncounterDetailScreen.kt
@@ -74,6 +74,7 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.OptionsAction
 import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.SubheadBar
 import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.Subtitle
 import cz.frantisekmasa.wfrp_master.common.encounters.domain.Encounter
+import cz.frantisekmasa.wfrp_master.common.npcs.NpcsScreenModel
 import dev.icerock.moko.resources.compose.stringResource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -85,6 +86,7 @@ class EncounterDetailScreen(
     @Composable
     override fun Content() {
         val screenModel: EncounterDetailScreenModel = rememberScreenModel(arg = encounterId)
+        val npcsScreenModel: NpcsScreenModel = rememberScreenModel(arg = encounterId.partyId)
 
         var startCombatDialogVisible by rememberSaveable { mutableStateOf(false) }
         val encounter = screenModel.encounter.collectWithLifecycle(null).value
@@ -134,7 +136,7 @@ class EncounterDetailScreen(
                     return@Scaffold
                 }
 
-                MainContainer(encounter, screenModel)
+                MainContainer(encounter, screenModel, npcsScreenModel)
 
                 if (startCombatDialogVisible) {
                     val navigation = LocalNavigationTransaction.current
@@ -219,6 +221,7 @@ class EncounterDetailScreen(
     private fun MainContainer(
         encounter: Encounter,
         screenModel: EncounterDetailScreenModel,
+        npcsScreenModel: NpcsScreenModel,
     ) {
         val coroutineScope = rememberCoroutineScope { EmptyCoroutineContext + Dispatchers.IO }
 
@@ -251,7 +254,7 @@ class EncounterDetailScreen(
 
             DescriptionCard(screenModel)
 
-            NpcCharacterList(encounterId.partyId, encounter, screenModel)
+            NpcCharacterList(encounterId.partyId, encounter, screenModel, npcsScreenModel)
         }
     }
 
@@ -283,6 +286,7 @@ private fun NpcCharacterList(
     partyId: PartyId,
     encounter: Encounter,
     screenModel: EncounterDetailScreenModel,
+    npcsScreenModel: NpcsScreenModel,
 ) {
     CardContainer(
         Modifier
@@ -337,8 +341,9 @@ private fun NpcCharacterList(
 
         if (chooseNpcDialogVisible) {
             ChooseNpcDialog(
-                encounter,
-                screenModel,
+                encounter = encounter,
+                screenModel = screenModel,
+                npcsScreenModel = npcsScreenModel,
                 onDismissRequest = { chooseNpcDialogVisible = false },
             )
         }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/EncounterDetailScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/EncounterDetailScreenModel.kt
@@ -12,7 +12,7 @@ import cz.frantisekmasa.wfrp_master.common.encounters.domain.EncounterRepository
 import kotlinx.coroutines.flow.Flow
 
 class EncounterDetailScreenModel(
-    private val encounterId: EncounterId,
+    val encounterId: EncounterId,
     private val encounters: EncounterRepository,
     private val characters: CharacterRepository,
     private val parties: PartyRepository,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/domain/EncounterRepository.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/encounters/domain/EncounterRepository.kt
@@ -13,6 +13,13 @@ interface EncounterRepository {
      */
     suspend fun get(id: EncounterId): Encounter
 
+    suspend fun find(id: EncounterId): Encounter? =
+        try {
+            get(id)
+        } catch (e: EncounterNotFound) {
+            null
+        }
+
     /**
      * Returns Encounter as flow that emits when stored version changes
      */

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/npcs/NpcList.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/npcs/NpcList.kt
@@ -1,0 +1,138 @@
+package cz.frantisekmasa.wfrp_master.common.npcs
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Divider
+import androidx.compose.material.ListItem
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import cz.frantisekmasa.wfrp_master.common.Str
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
+import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
+import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
+import cz.frantisekmasa.wfrp_master.common.core.ui.CharacterAvatar
+import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.AlertDialog
+import cz.frantisekmasa.wfrp_master.common.core.ui.menu.WithContextMenu
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.ContextMenu
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.EmptyUI
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.ItemIcon
+import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.SearchableList
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
+import dev.icerock.moko.resources.compose.stringResource
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@Composable
+fun NpcList(
+    title: String,
+    navigationIcon: @Composable () -> Unit,
+    screenModel: NpcsScreenModel,
+    floatingActionButton: @Composable () -> Unit,
+    onClick: (CharacterId) -> Unit,
+    data: SearchableList.Data<Character>,
+) {
+    var processing by remember { mutableStateOf(false) }
+
+    val (npcToRemove, setNpcToRemove) = remember { mutableStateOf<Character?>(null) }
+
+    val coroutineScope = rememberCoroutineScope()
+
+    if (npcToRemove != null) {
+        AlertDialog(
+            onDismissRequest = { setNpcToRemove(null) },
+            text = { Text(stringResource(Str.npcs_messages_removal_confirmation)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        coroutineScope.launch(Dispatchers.IO) {
+                            processing = true
+                            setNpcToRemove(null)
+                            screenModel.archiveNpc(npcToRemove)
+                            processing = false
+                        }
+                    },
+                ) {
+                    Text(stringResource(Str.common_ui_button_remove).uppercase())
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { setNpcToRemove(null) }) {
+                    Text(stringResource(Str.common_ui_button_cancel).uppercase())
+                }
+            },
+        )
+    }
+
+    val derivedData by derivedStateOf {
+        if (processing) {
+            return@derivedStateOf SearchableList.Data.Loading
+        }
+
+        data
+    }
+
+    SearchableList(
+        data = derivedData,
+        navigationIcon = navigationIcon,
+        title = title,
+        searchPlaceholder = stringResource(Str.npcs_search_placeholder),
+        emptyUi = {
+            EmptyUI(
+                text = stringResource(Str.npcs_messages_no_npcs),
+                subText = stringResource(Str.npcs_messages_no_npcs_subtext),
+                icon = Resources.Drawable.Npc,
+            )
+        },
+        key = { it.id },
+        searchableValue = { it.name },
+        floatingActionButton = floatingActionButton,
+    ) { npc ->
+        Column {
+            val unknownErrorMessage = stringResource(Str.messages_error_unknown)
+            val snackbarHolder = LocalPersistentSnackbarHolder.current
+
+            WithContextMenu(
+                onClick = { onClick(CharacterId(screenModel.partyId, npc.id)) },
+                items =
+                    listOf(
+                        ContextMenu.Item(stringResource(Str.common_ui_button_duplicate)) {
+                            coroutineScope.launch(Dispatchers.IO) {
+                                processing = true
+                                try {
+                                    screenModel.duplicate(npc)
+                                } catch (e: Exception) {
+                                    Napier.e("Failed to duplicate NPC", e)
+                                    snackbarHolder.showSnackbar(unknownErrorMessage)
+                                } finally {
+                                    processing = false
+                                }
+                            }
+                        },
+                        ContextMenu.Item(stringResource(Str.common_ui_button_remove)) {
+                            setNpcToRemove(npc)
+                        },
+                    ),
+            ) {
+                ListItem(
+                    icon = {
+                        CharacterAvatar(
+                            npc.avatarUrl,
+                            ItemIcon.Size.Small,
+                            fallback = Resources.Drawable.Npc,
+                        )
+                    },
+                    text = { Text(npc.name) },
+                )
+            }
+
+            Divider()
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/npcs/NpcsScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/npcs/NpcsScreen.kt
@@ -1,46 +1,24 @@
 package cz.frantisekmasa.wfrp_master.common.npcs
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.material.Divider
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
-import androidx.compose.material.ListItem
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import cafe.adriel.voyager.core.screen.Screen
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.CharacterDetailScreen
 import cz.frantisekmasa.wfrp_master.common.characterCreation.CharacterCreationScreen
-import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterType
-import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
-import cz.frantisekmasa.wfrp_master.common.core.shared.Resources
-import cz.frantisekmasa.wfrp_master.common.core.ui.CharacterAvatar
 import cz.frantisekmasa.wfrp_master.common.core.ui.buttons.HamburgerButton
-import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.AlertDialog
 import cz.frantisekmasa.wfrp_master.common.core.ui.flow.collectWithLifecycle
-import cz.frantisekmasa.wfrp_master.common.core.ui.menu.WithContextMenu
 import cz.frantisekmasa.wfrp_master.common.core.ui.navigation.LocalNavigationTransaction
-import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.ContextMenu
-import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.EmptyUI
-import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.ItemIcon
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.SearchableList
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.rememberScreenModel
-import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
 import dev.icerock.moko.resources.compose.stringResource
-import io.github.aakira.napier.Napier
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 class NpcsScreen(
     private val partyId: PartyId,
@@ -48,63 +26,20 @@ class NpcsScreen(
     @Composable
     override fun Content() {
         val navigation = LocalNavigationTransaction.current
-        var processing by remember { mutableStateOf(false) }
-
         val screenModel: NpcsScreenModel = rememberScreenModel(arg = partyId)
+
         val npcs by screenModel.npcs.collectWithLifecycle(null)
-        val (npcToRemove, setNpcToRemove) = remember { mutableStateOf<Character?>(null) }
-
         val data by derivedStateOf {
-            if (processing) {
-                return@derivedStateOf SearchableList.Data.Loading
-            }
-
             npcs?.let { SearchableList.Data.Loaded(it) }
                 ?: SearchableList.Data.Loading
         }
 
-        val coroutineScope = rememberCoroutineScope()
-
-        if (npcToRemove != null) {
-            AlertDialog(
-                onDismissRequest = { setNpcToRemove(null) },
-                text = { Text(stringResource(Str.npcs_messages_removal_confirmation)) },
-                confirmButton = {
-                    TextButton(
-                        onClick = {
-                            coroutineScope.launch(Dispatchers.IO) {
-                                processing = true
-                                setNpcToRemove(null)
-                                screenModel.archiveNpc(npcToRemove)
-                                processing = false
-                            }
-                        },
-                    ) {
-                        Text(stringResource(Str.common_ui_button_remove).uppercase())
-                    }
-                },
-                dismissButton = {
-                    TextButton(onClick = { setNpcToRemove(null) }) {
-                        Text(stringResource(Str.common_ui_button_cancel).uppercase())
-                    }
-                },
-            )
-        }
-
-        SearchableList(
-            data = data,
-            navigationIcon = { HamburgerButton() },
+        NpcList(
             title = stringResource(Str.npcs_title_plural),
-            searchPlaceholder = stringResource(Str.npcs_search_placeholder),
-            emptyUi = {
-                EmptyUI(
-                    text = stringResource(Str.npcs_messages_no_npcs),
-                    subText = stringResource(Str.npcs_messages_no_npcs_subtext),
-                    icon = Resources.Drawable.Npc,
-                )
-            },
-            key = { it.id },
-            searchableValue = { it.name },
+            navigationIcon = { HamburgerButton() },
+            data = data,
+            onClick = { navigation.navigate(CharacterDetailScreen(it)) },
+            screenModel = screenModel,
             floatingActionButton = {
                 FloatingActionButton(
                     onClick = {
@@ -116,49 +51,6 @@ class NpcsScreen(
                     Icon(Icons.Rounded.Add, stringResource(Str.npcs_button_add_npc))
                 }
             },
-        ) { npc ->
-            Column {
-                val unknownErrorMessage = stringResource(Str.messages_error_unknown)
-                val snackbarHolder = LocalPersistentSnackbarHolder.current
-
-                WithContextMenu(
-                    onClick = {
-                        navigation.navigate(CharacterDetailScreen(CharacterId(partyId, npc.id)))
-                    },
-                    items =
-                        listOf(
-                            ContextMenu.Item(stringResource(Str.common_ui_button_duplicate)) {
-                                coroutineScope.launch(Dispatchers.IO) {
-                                    processing = true
-                                    try {
-                                        screenModel.duplicate(npc)
-                                    } catch (e: Exception) {
-                                        Napier.e("Failed to duplicate NPC", e)
-                                        snackbarHolder.showSnackbar(unknownErrorMessage)
-                                    } finally {
-                                        processing = false
-                                    }
-                                }
-                            },
-                            ContextMenu.Item(stringResource(Str.common_ui_button_remove)) {
-                                setNpcToRemove(npc)
-                            },
-                        ),
-                ) {
-                    ListItem(
-                        icon = {
-                            CharacterAvatar(
-                                npc.avatarUrl,
-                                ItemIcon.Size.Small,
-                                fallback = Resources.Drawable.Npc,
-                            )
-                        },
-                        text = { Text(npc.name) },
-                    )
-                }
-
-                Divider()
-            }
-        }
+        )
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/npcs/NpcsScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/npcs/NpcsScreenModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.Serializable
 
 class NpcsScreenModel(
-    private val partyId: PartyId,
+    val partyId: PartyId,
     private val functions: FirebaseFunctions,
     private val characters: CharacterRepository,
 ) : ScreenModel {


### PR DESCRIPTION
GMs can now create, duplicate delete NPCs directly from "Add NPC" dialog in Encounter detail.