### PR TITLE
Fetching PCs in Party in advance

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/DependencyInjection.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/DependencyInjection.kt
@@ -349,7 +349,7 @@ val appModule =
             )
         }
         bindProvider { InvitationScreenModel(instance(), instance(), instance()) }
-        bindProvider { PartyListScreenModel(instance()) }
+        bindProvider { PartyListScreenModel(instance(), instance()) }
         bindProvider { SettingsScreenModel(instance(), instance()) }
         bindFactory { partyId: PartyId ->
             CharacterCreationScreenModel(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/CharacterRepository.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/CharacterRepository.kt
@@ -2,6 +2,7 @@ package cz.frantisekmasa.wfrp_master.common.core.domain.character
 
 import arrow.core.Either
 import com.benasher44.uuid.Uuid
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import dev.gitlive.firebase.firestore.Transaction
@@ -30,6 +31,8 @@ interface CharacterRepository {
         userId: String,
         partyId: PartyId,
     ): Boolean
+
+    fun getPlayerCharactersInAllPartiesLive(userId: UserId): Flow<List<Pair<PartyId, Character>>>
 
     suspend fun findByCompendiumCareer(
         partyId: PartyId,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/CharacterRepository.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/CharacterRepository.kt
@@ -27,11 +27,6 @@ interface CharacterRepository {
 
     fun getLive(characterId: CharacterId): Flow<Either<CharacterNotFound, Character>>
 
-    suspend fun hasCharacterInParty(
-        userId: String,
-        partyId: PartyId,
-    ): Boolean
-
     fun getPlayerCharactersInAllPartiesLive(userId: UserId): Flow<List<Pair<PartyId, Character>>>
 
     suspend fun findByCompendiumCareer(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/firebase/repositories/FirestoreCharacterRepository.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/firebase/repositories/FirestoreCharacterRepository.kt
@@ -3,6 +3,8 @@ package cz.frantisekmasa.wfrp_master.common.core.firebase.repositories
 import arrow.core.left
 import arrow.core.right
 import com.benasher44.uuid.Uuid
+import com.benasher44.uuid.uuidFrom
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterNotFound
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterRepository
@@ -21,7 +23,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 class FirestoreCharacterRepository(
-    firestore: FirebaseFirestore,
+    private val firestore: FirebaseFirestore,
 ) : CharacterRepository {
     private val parties = firestore.collection(Schema.PARTIES)
 
@@ -90,6 +92,18 @@ class FirestoreCharacterRepository(
             .get()
             .documents
             .isNotEmpty()
+    }
+
+    override fun getPlayerCharactersInAllPartiesLive(userId: UserId): Flow<List<Pair<PartyId, Character>>> {
+        return firestore.collectionGroup(Schema.CHARACTERS)
+            .where { ("userId" equalTo userId.toString()) and ("archived" equalTo false) }
+            .snapshots
+            .map { snapshot ->
+                snapshot.documents.map {
+                    PartyId(uuidFrom(it.reference.parent.parent!!.id)) to
+                        it.data(Character.serializer())
+                }
+            }
     }
 
     override suspend fun findByCompendiumCareer(

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/firebase/repositories/FirestoreCharacterRepository.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/firebase/repositories/FirestoreCharacterRepository.kt
@@ -83,17 +83,6 @@ class FirestoreCharacterRepository(
                 }
             }
 
-    override suspend fun hasCharacterInParty(
-        userId: String,
-        partyId: PartyId,
-    ): Boolean {
-        return characters(partyId)
-            .where("userId", equalTo = userId)
-            .get()
-            .documents
-            .isNotEmpty()
-    }
-
     override fun getPlayerCharactersInAllPartiesLive(userId: UserId): Flow<List<Pair<PartyId, Character>>> {
         return firestore.collectionGroup(Schema.CHARACTERS)
             .where { ("userId" equalTo userId.toString()) and ("archived" equalTo false) }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/partyList/LeavePartyDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/partyList/LeavePartyDialog.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.core.auth.LocalUser
-import cz.frantisekmasa.wfrp_master.common.core.domain.party.Party
 import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.AlertDialog
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
 import dev.icerock.moko.resources.compose.stringResource
@@ -21,7 +20,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun LeavePartyDialog(
-    party: Party,
+    party: PartyListItem,
     screenModel: PartyListScreenModel,
     onDismissRequest: () -> Unit,
 ) {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/partyList/PartyListScreenModel.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/partyList/PartyListScreenModel.kt
@@ -2,6 +2,8 @@ package cz.frantisekmasa.wfrp_master.common.partyList
 
 import cafe.adriel.voyager.core.model.ScreenModel
 import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterRepository
+import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.Party
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyId
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.PartyRepository
@@ -10,12 +12,30 @@ import cz.frantisekmasa.wfrp_master.common.core.logging.Reporter
 import cz.frantisekmasa.wfrp_master.common.settings.Language
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 
 class PartyListScreenModel(
     private val parties: PartyRepository,
+    private val characters: CharacterRepository,
 ) : ScreenModel {
-    fun liveForUser(userId: UserId): Flow<List<Party>> {
-        return parties.forUserLive(userId)
+    fun liveForUser(userId: UserId): Flow<List<PartyListItem>> {
+        return combine(
+            parties.forUserLive(userId),
+            characters.getPlayerCharactersInAllPartiesLive(userId),
+        ) { parties, characters ->
+            val charactersByParty = characters.groupBy({ it.first }) { CharacterId(it.first, it.second.id) }
+
+            parties.map { party ->
+                PartyListItem(
+                    id = party.id,
+                    party = party,
+                    name = party.name,
+                    isGameMaster = party.gameMasterId == userId || party.gameMasterId == null,
+                    singleCharacterId = charactersByParty[party.id]?.singleOrNull(),
+                    playersCount = party.playersCount,
+                )
+            }
+        }
     }
 
     suspend fun archive(partyId: PartyId) {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/partyList/RemovePartyDialog.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/partyList/RemovePartyDialog.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.font.FontWeight
 import cz.frantisekmasa.wfrp_master.common.Str
-import cz.frantisekmasa.wfrp_master.common.core.domain.party.Party
 import cz.frantisekmasa.wfrp_master.common.core.ui.dialogs.AlertDialog
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.Spacing
 import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.LocalPersistentSnackbarHolder
@@ -23,7 +22,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun RemovePartyDialog(
-    party: Party,
+    party: PartyListItem,
     screenModel: PartyListScreenModel,
     onDismissRequest: () -> Unit,
 ) {

--- a/common/src/commonTest/kotlin/cz/frantisekmasa/wfrp_master/common/dummies/DummyCharacterRepository.kt
+++ b/common/src/commonTest/kotlin/cz/frantisekmasa/wfrp_master/common/dummies/DummyCharacterRepository.kt
@@ -44,13 +44,6 @@ class DummyCharacterRepository : CharacterRepository {
         )
     }
 
-    override suspend fun hasCharacterInParty(
-        userId: String,
-        partyId: PartyId,
-    ): Boolean {
-        return characters[partyId]?.any { it.value.userId?.toString() == userId } ?: false
-    }
-
     override fun getPlayerCharactersInAllPartiesLive(userId: UserId): Flow<List<Pair<PartyId, Character>>> {
         return flowOf(
             characters.entries

--- a/common/src/commonTest/kotlin/cz/frantisekmasa/wfrp_master/common/dummies/DummyCharacterRepository.kt
+++ b/common/src/commonTest/kotlin/cz/frantisekmasa/wfrp_master/common/dummies/DummyCharacterRepository.kt
@@ -3,6 +3,7 @@ package cz.frantisekmasa.wfrp_master.common.dummies
 import arrow.core.Either
 import arrow.core.rightIfNotNull
 import com.benasher44.uuid.Uuid
+import cz.frantisekmasa.wfrp_master.common.core.auth.UserId
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterNotFound
 import cz.frantisekmasa.wfrp_master.common.core.domain.character.CharacterRepository
@@ -48,6 +49,21 @@ class DummyCharacterRepository : CharacterRepository {
         partyId: PartyId,
     ): Boolean {
         return characters[partyId]?.any { it.value.userId?.toString() == userId } ?: false
+    }
+
+    override fun getPlayerCharactersInAllPartiesLive(userId: UserId): Flow<List<Pair<PartyId, Character>>> {
+        return flowOf(
+            characters.entries
+                .asSequence()
+                .flatMap { (partyId, characters) ->
+                    characters
+                        .values
+                        .asSequence()
+                        .filter { it.userId == userId }
+                        .map { partyId to it }
+                }
+                .toList(),
+        )
     }
 
     override suspend fun findByCompendiumCareer(

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -8,6 +8,14 @@
         { "fieldPath": "type", "order": "ASCENDING" },
         { "fieldPath": "name", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "characters",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath":  "userId", "order": "ASCENDING" },
+        { "fieldPath": "archived", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -2,6 +2,10 @@ rules_version = '2';
 
 service cloud.firestore {
     match /databases/{database}/documents {
+        // Let users search for all their Characters across the parties
+        match /{path=**}/characters/{characterId} {
+          allow read: if request.auth.uid != null || resource.data.userId == request.auth.uid;
+        }
 
         match /parties/{party=**} {
             allow read: if request.auth.uid != null


### PR DESCRIPTION
This PR is intended to solve the janky screen transition when the Player clicks on Party, the Character Picker screen is shown and then immediately replaced by the Character Detail screen when the Player has only one Character in a given Party.

Now PCs for Party are fetched on the Party List screen, so we immediately know whether we should open Character Picker or Character Detail.

`PartyListScreen` now also uses purpose-built DTO `PartyItem` instead of working with `Party` directly. I figured out that components currently contain a lot of logic that should ideally live in screen model and be exposed in a state passed to the UI. So this is the first step.