### PR TITLE
Corruption points counter in Wellbeing tab

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CharacterDetailScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/CharacterDetailScreen.kt
@@ -382,6 +382,7 @@ data class CharacterDetailScreen(
                                     state = state.wellBeingScreenState,
                                     removeDisease = screenModelV2::removeDisease,
                                     modifier = modifier,
+                                    updateCharacter = screenModelV2::updateCharacter,
                                 )
                             }
                             CharacterTab.NOTES -> {

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/effects/CorruptionPointsBufferBonus.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/effects/CorruptionPointsBufferBonus.kt
@@ -1,0 +1,43 @@
+package cz.frantisekmasa.wfrp_master.common.character.effects
+
+import cz.frantisekmasa.wfrp_master.common.Str
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
+import cz.frantisekmasa.wfrp_master.common.localization.Translator
+
+class CorruptionPointsBufferBonus(
+    private val bonus: Int,
+): CharacterEffect {
+    override fun apply(
+        character: Character,
+        otherEffects: List<CharacterEffect>,
+    ): Character {
+        return character.modifyCorruptionBufferBonus(
+            bonus +
+                otherEffects.filterIsInstance<CorruptionPointsBufferBonus>().sumOf { it.bonus },
+        )
+    }
+
+    override fun revert(
+        character: Character,
+        otherEffects: List<CharacterEffect>,
+    ): Character {
+        return character.modifyCorruptionBufferBonus(
+            otherEffects.filterIsInstance<CorruptionPointsBufferBonus>()
+                .sumOf { it.bonus },
+        )
+    }
+
+    companion object {
+        fun fromTalentOrNull(
+            name: String,
+            translator: Translator,
+            timesTaken: Int,
+        ): CorruptionPointsBufferBonus? {
+            if (name.equals(translator.translate(Str.character_effect_pure_soul), ignoreCase = true)) {
+                return CorruptionPointsBufferBonus(timesTaken)
+            }
+
+            return null
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/effects/CorruptionPointsBufferBonus.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/effects/CorruptionPointsBufferBonus.kt
@@ -6,7 +6,7 @@ import cz.frantisekmasa.wfrp_master.common.localization.Translator
 
 class CorruptionPointsBufferBonus(
     private val bonus: Int,
-): CharacterEffect {
+) : CharacterEffect {
     override fun apply(
         character: Character,
         otherEffects: List<CharacterEffect>,

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/wellBeing/WellBeingScreen.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/wellBeing/WellBeingScreen.kt
@@ -1,18 +1,29 @@
 package cz.frantisekmasa.wfrp_master.common.character.wellBeing
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.character.wellBeing.diseases.DiseaseItem
 import cz.frantisekmasa.wfrp_master.common.character.wellBeing.diseases.diseasesCard
+import cz.frantisekmasa.wfrp_master.common.core.domain.character.Character
 import cz.frantisekmasa.wfrp_master.common.core.domain.identifiers.CharacterId
 import cz.frantisekmasa.wfrp_master.common.core.ui.cards.CardContainer
+import cz.frantisekmasa.wfrp_master.common.core.ui.forms.NumberPicker
 import cz.frantisekmasa.wfrp_master.common.core.ui.responsive.Breakpoint
 import cz.frantisekmasa.wfrp_master.common.core.ui.responsive.LocalBreakpoint
+import cz.frantisekmasa.wfrp_master.common.core.ui.scaffolding.TopPanel
+import dev.icerock.moko.resources.compose.stringResource
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 @Composable
 fun WellBeingScreen(
@@ -20,6 +31,7 @@ fun WellBeingScreen(
     modifier: Modifier = Modifier,
     state: WellBeingScreenState,
     removeDisease: (DiseaseItem) -> Unit,
+    updateCharacter: suspend ((Character) -> Character) -> Unit,
 ) {
     val diseasesCard: LazyListScope.() -> Unit = {
         diseasesCard(
@@ -28,20 +40,59 @@ fun WellBeingScreen(
             onRemoveRequest = removeDisease,
         )
     }
+    Column {
+        CorruptionPoints(
+            pool = state.corruptionPoints,
+            updateCharacter = updateCharacter,
+        )
 
-    if (LocalBreakpoint.current > Breakpoint.XSmall) {
-        CardContainer(Modifier) {
-            LazyColumn(Modifier.fillMaxWidth()) {
+        if (LocalBreakpoint.current > Breakpoint.XSmall) {
+            CardContainer(Modifier) {
+                LazyColumn(Modifier.fillMaxWidth()) {
+                    diseasesCard()
+                }
+            }
+        } else {
+            LazyColumn(
+                modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(),
+            ) {
                 diseasesCard()
             }
         }
-    } else {
-        LazyColumn(
-            modifier
-                .fillMaxWidth()
-                .fillMaxHeight(),
+    }
+}
+
+@Composable
+private fun CorruptionPoints(
+    pool: CorruptionPoints,
+    updateCharacter: suspend ((Character) -> Character) -> Unit,
+) {
+    TopPanel {
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            diseasesCard()
+            val current = pool.current
+            val coroutineScope = rememberCoroutineScope()
+            val updateCorruptionPoints = { corruptionPoints: Int ->
+                if (corruptionPoints != current) {
+                    coroutineScope.launch(Dispatchers.IO) {
+                        updateCharacter {
+                            it.updatePoints(it.points.copy(corruption = corruptionPoints))
+                        }
+                    }
+                }
+            }
+
+            NumberPicker(
+                label = stringResource(Str.points_corruption),
+                max = pool.buffer,
+                value = current,
+                onIncrement = { updateCorruptionPoints(current + 1) },
+                onDecrement = { updateCorruptionPoints((current - 1).coerceAtLeast(0)) },
+            )
         }
     }
 }

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/Character.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/character/Character.kt
@@ -110,17 +110,17 @@ data class Character(
             characteristicsBase = base,
             characteristicsAdvances = advances,
             points =
-            points.copy(
-                wounds =
-                points.wounds.coerceAtMost(
-                    calculateMaxWounds(
-                        size ?: race?.size,
-                        points,
-                        woundsModifiers,
-                        base + advances,
-                    ),
+                points.copy(
+                    wounds =
+                        points.wounds.coerceAtMost(
+                            calculateMaxWounds(
+                                size ?: race?.size,
+                                points,
+                                woundsModifiers,
+                                base + advances,
+                            ),
+                        ),
                 ),
-            ),
         )
     }
 
@@ -128,17 +128,17 @@ data class Character(
         return copy(
             size = size,
             points =
-            points.copy(
-                wounds =
-                points.wounds.coerceAtMost(
-                    calculateMaxWounds(
-                        size ?: race?.size,
-                        points,
-                        woundsModifiers,
-                        characteristics,
-                    ),
+                points.copy(
+                    wounds =
+                        points.wounds.coerceAtMost(
+                            calculateMaxWounds(
+                                size ?: race?.size,
+                                points,
+                                woundsModifiers,
+                                characteristics,
+                            ),
+                        ),
                 ),
-            ),
         )
     }
 
@@ -146,17 +146,17 @@ data class Character(
         return copy(
             woundsModifiers = woundsModifiers,
             points =
-            points.copy(
-                wounds =
-                points.wounds.coerceAtMost(
-                    calculateMaxWounds(
-                        size ?: race?.size,
-                        points,
-                        woundsModifiers,
-                        characteristics,
-                    ),
+                points.copy(
+                    wounds =
+                        points.wounds.coerceAtMost(
+                            calculateMaxWounds(
+                                size ?: race?.size,
+                                points,
+                                woundsModifiers,
+                                characteristics,
+                            ),
+                        ),
                 ),
-            ),
         )
     }
 
@@ -193,28 +193,28 @@ data class Character(
         motivation = motivation,
         note = note,
         points =
-        points.coerceWoundsAtMost(
-            calculateMaxWounds(
-                size ?: race?.size,
-                points,
-                woundsModifiers,
-                characteristics,
+            points.coerceWoundsAtMost(
+                calculateMaxWounds(
+                    size ?: race?.size,
+                    points,
+                    woundsModifiers,
+                    characteristics,
+                ),
             ),
-        ),
     )
 
     fun updateMaxWounds(maxWounds: Int?): Character {
         val newPoints = points.copy(maxWounds = maxWounds)
         return copy(
             points =
-            newPoints.coerceWoundsAtMost(
-                calculateMaxWounds(
-                    size ?: race?.size,
-                    newPoints,
-                    woundsModifiers,
-                    characteristics,
+                newPoints.coerceWoundsAtMost(
+                    calculateMaxWounds(
+                        size ?: race?.size,
+                        newPoints,
+                        woundsModifiers,
+                        characteristics,
+                    ),
                 ),
-            ),
         )
     }
 
@@ -315,11 +315,11 @@ data class Character(
                     toughnessBonus = toughnessBonus,
                     strengthBonus = characteristics.strengthBonus,
                     willPowerBonus =
-                    if (modifiers.isConstruct) {
-                        characteristics.strengthBonus
-                    } else {
-                        characteristics.willPowerBonus
-                    },
+                        if (modifiers.isConstruct) {
+                            characteristics.strengthBonus
+                        } else {
+                            characteristics.willPowerBonus
+                        },
                 )
             return (baseWounds + modifiers.extraToughnessBonusMultiplier * toughnessBonus) *
                 modifiers.afterMultiplier

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/talents/Talent.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/domain/talents/Talent.kt
@@ -6,6 +6,7 @@ import com.benasher44.uuid.uuid4
 import cz.frantisekmasa.wfrp_master.common.character.effects.AdditionalEncumbrance
 import cz.frantisekmasa.wfrp_master.common.character.effects.CharacterEffect
 import cz.frantisekmasa.wfrp_master.common.character.effects.CharacteristicChange
+import cz.frantisekmasa.wfrp_master.common.character.effects.CorruptionPointsBufferBonus
 import cz.frantisekmasa.wfrp_master.common.character.effects.EffectSource
 import cz.frantisekmasa.wfrp_master.common.character.effects.HardyWoundsModification
 import cz.frantisekmasa.wfrp_master.common.core.common.requireMaxLength
@@ -38,6 +39,7 @@ data class Talent(
             HardyWoundsModification.fromTalentOrNull(name, translator, taken),
             CharacteristicChange.fromTalentNameOrNull(name, translator),
             AdditionalEncumbrance.fromTalentOrNull(name, translator, taken),
+            CorruptionPointsBufferBonus.fromTalentOrNull(name, translator, taken),
         )
     }
 

--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/forms/NumberPicker.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/core/ui/forms/NumberPicker.kt
@@ -25,6 +25,7 @@ import dev.icerock.moko.resources.compose.stringResource
 fun NumberPicker(
     value: Int,
     modifier: Modifier = Modifier,
+    max: Int? = null,
     label: String? = null,
     color: Color = MaterialTheme.colors.onSurface,
     onIncrement: () -> Unit,
@@ -59,7 +60,7 @@ fun NumberPicker(
             }
 
             Text(
-                value.toString(),
+                max?.let { "$value / $it" } ?: value.toString(),
                 style = MaterialTheme.typography.h5,
                 color = color,
             )

--- a/common/src/commonMain/moko-resources/base/strings.xml
+++ b/common/src/commonMain/moko-resources/base/strings.xml
@@ -124,6 +124,7 @@
     <string name="character_effect_lightning_reflexes">lightning reflexes</string>
     <string name="character_effect_marksman">marksman</string>
     <string name="character_effect_nimble_fingered">nimble fingered</string>
+    <string name="character_effect_pure_soul">pure soul</string>
     <string name="character_effect_savvy">savvy</string>
     <string name="character_effect_sharp">sharp</string>
     <string name="character_effect_size">size</string>

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -606,7 +606,8 @@ service cloud.firestore {
                             "archived",
                             "woundsModifiers",
                             "compendiumCareer",
-                            "encumbranceBonus"
+                            "encumbranceBonus",
+                            "corruptionBufferBonus"
                         ].hasAll(character.keys())
                         && character.id == characterId
                         && (character.userId == null || character.userId in get(/databases/$(database)/documents/parties/$(partyId)).data.users)
@@ -663,7 +664,8 @@ service cloud.firestore {
                         )
                         && areValidWoundsModifiers(character.woundsModifiers)
                         && (character.compendiumCareer == null || isCompendiumCareerValid(character.compendiumCareer))
-                        && character.encumbranceBonus is number && character.encumbranceBonus >= 0;
+                        && character.encumbranceBonus is number && character.encumbranceBonus >= 0
+                        && ( !("corruptionBufferBonus" in character) || (character.corruptionBufferBonus is int && character.corruptionBufferBonus >= 0));
                 }
             }
 


### PR DESCRIPTION
Also adds support for *Pure Soul* talent, that automatically increases number of corruption points character can take without mutating.