### PR TITLE
Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/desktop_distribution.yml
+++ b/.github/workflows/desktop_distribution.yml
@@ -49,7 +49,7 @@ jobs:
           conveyor_version: "8.0"
           cache_key: conveyor-${{ matrix.os }}-${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: download-page
           path: output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
       - run: ./gradlew bundleRelease
       - run: mv app/build/outputs/bundle/release/app-release.aab .
       - name: Upload bundle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bundle
           path: app-release.aab


### PR DESCRIPTION
Previous version [no longer works](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).