### PR TITLE
Replace Firebase Dynamic Links by Android App Links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,11 +39,17 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:host="dnd-master-58fca.web.app" android:pathPrefix="/app/" android:scheme="https"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="wfrp-master"/>
             </intent-filter>
         </activity>
     </application>

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -124,7 +124,6 @@ kotlin {
 
                 // Authentication
                 api(libs.play.services.auth)
-                implementation(libs.firebase.dynamic.links.ktx)
 
                 // Shared Preferences DataStore
                 api(libs.datastore.preferences)

--- a/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/invitation/InvitationDialogContent.kt
+++ b/common/src/androidMain/kotlin/cz/frantisekmasa/wfrp_master/common/invitation/InvitationDialogContent.kt
@@ -16,11 +16,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
-import androidx.core.net.toUri
-import com.google.firebase.dynamiclinks.ktx.androidParameters
-import com.google.firebase.dynamiclinks.ktx.dynamicLinks
-import com.google.firebase.dynamiclinks.ktx.shortLinkAsync
-import com.google.firebase.ktx.Firebase
 import cz.frantisekmasa.wfrp_master.common.Str
 import cz.frantisekmasa.wfrp_master.common.core.domain.party.Invitation
 import cz.frantisekmasa.wfrp_master.common.core.logging.Reporting
@@ -28,7 +23,6 @@ import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.FullScreenProgress
 import cz.frantisekmasa.wfrp_master.common.core.ui.primitives.VISUAL_ONLY_ICON_DESCRIPTION
 import dev.icerock.moko.resources.compose.stringResource
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 
 @Composable
@@ -74,15 +68,10 @@ private suspend fun buildSharingOptions(
 ): SharingOptions {
     return withContext(Dispatchers.IO) {
         val json = screenModel.serializeInvitation(invitation)
-        val link =
-            Firebase.dynamicLinks.shortLinkAsync {
-                link = InvitationLinkScreen.deepLink(json).toString().toUri()
-                androidParameters { }
-                domainUriPrefix = "https://wfrp.page.link"
-            }
+        val link = InvitationLinkScreen.deepLink(json).toString()
 
         SharingOptions(
-            link = link.await().shortLink.toString(),
+            link = link,
             json = json,
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ datastore-preferences = "1.1.2"
 datetime-dialog = "0.5.1"
 debounce = "1.2.0"
 desugar-jdk-libs = "2.1.4"
-firebase-dynamic-links-ktx = "22.1.0"
 gitlive-firebase = "2.1.0"
 google-services = "4.4.2"
 junit-jupiter-engine = "5.8.2"
@@ -58,7 +57,6 @@ debounce = { module = "io.github.mmolosay:debounce", version.ref = "debounce" }
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar-jdk-libs" }
 firebase-auth = { module = "dev.gitlive:firebase-auth", version.ref = "gitlive-firebase" }
 firebase-common = { module = "dev.gitlive:firebase-common", version.ref = "gitlive-firebase" }
-firebase-dynamic-links-ktx = { module = "com.google.firebase:firebase-dynamic-links-ktx", version.ref = "firebase-dynamic-links-ktx" }
 firebase-analytics = { module = "dev.gitlive:firebase-analytics", version.ref = "gitlive-firebase" }
 firebase-crashlytics = { module = "dev.gitlive:firebase-crashlytics", version.ref = "gitlive-firebase" }
 firebase-firestore = { module = "dev.gitlive:firebase-firestore", version.ref = "gitlive-firebase" }

--- a/webapp/.well-known/assetlinks.json
+++ b/webapp/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.example",
+      "sha256_cert_fingerprints": [
+        "E2:C6:D6:EC:B9:ED:D4:ED:BE:0B:98:3A:69:9D:70:EB:95:71:C0:6F:7E:A1:CB:FF:6D:92:75:80:8F:80:CE:1B"
+      ]
+    }
+  }
+]

--- a/webapp/.well-known/assetlinks.json
+++ b/webapp/.well-known/assetlinks.json
@@ -5,7 +5,7 @@
     ],
     "target": {
       "namespace": "android_app",
-      "package_name": "com.example",
+      "package_name": "cz.frantisekmasa.dnd",
       "sha256_cert_fingerprints": [
         "E2:C6:D6:EC:B9:ED:D4:ED:BE:0B:98:3A:69:9D:70:EB:95:71:C0:6F:7E:A1:CB:FF:6D:92:75:80:8F:80:CE:1B"
       ]

--- a/webapp/app.css
+++ b/webapp/app.css
@@ -94,6 +94,10 @@ body {
     clear: both;
 }
 
+.text-center {
+    text-align: center;
+}
+
 @media (max-width: 600px) {
     body, #message {
         margin-top: 0;

--- a/webapp/app/invitation.html
+++ b/webapp/app/invitation.html
@@ -23,6 +23,7 @@
     <p>You have been invited to WFRP Master party.</p>
     <p>Open this page on your Android device to join it, or scan QR code below in WFRP Master app.</p>
     <div id="qrCode" style="margin: auto; width: 200px"></div>
+    <p>If you are visiting this page on your Android device and the app did not open <a id="open-app" href="">click here</a>.</p>
     <div class="clear"></div>
 </div>
 <div id="footer">
@@ -31,7 +32,7 @@
     <a href="/privacy-policy.html">Privacy Policy</a>
 </div>
 <script src="https://cdn.rawgit.com/davidshimjs/qrcodejs/gh-pages/qrcode.min.js"></script>
-<script>
+<script type="text/javascript">
     const urlParams = new URLSearchParams(window.location.search);
     const invitation = urlParams.get('invitation');
 
@@ -40,6 +41,8 @@
         width: 200,
         height: 200,
     });
+
+    document.getElementById("open-app").href = "wfrp-master://invitation?invitation=" + encodeURIComponent(invitation);
 </script>
 </body>
 </html>

--- a/webapp/app/invitation.html
+++ b/webapp/app/invitation.html
@@ -11,20 +11,17 @@
 <div id="header">
     <h1>WFRP Master</h1>
 </div>
-<div id="message">
-    <div class="main-screenshot">
-        <img src="/screenshot.png" alt="Screenshot of WFRP Master" style="width: 100%">
-        <a href="https://play.google.com/store/apps/details?id=cz.frantisekmasa.dnd&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"><img
-                alt="Get it on Google Play"
-                width="200"
-                src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"/></a>
-    </div>
+<div id="message" class="text-center">
     <h1>Invitation</h1>
     <p>You have been invited to WFRP Master party.</p>
     <p>Open this page on your Android device to join it, or scan QR code below in WFRP Master app.</p>
     <div id="qrCode" style="margin: auto; width: 200px"></div>
     <p>If you are visiting this page on your Android device and the app did not open <a id="open-app" href="">click here</a>.</p>
-    <div class="clear"></div>
+    <p>If you don't have the app installed yet, you can <a href="https://play.google.com/store/apps/details?id=cz.frantisekmasa.dnd&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">install it from Google Play</a>.</p>
+    <a href="https://play.google.com/store/apps/details?id=cz.frantisekmasa.dnd&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"><img
+            alt="Get it on Google Play"
+            width="200"
+            src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"/></a>
 </div>
 <div id="footer">
     <p>WFRP Master</p>


### PR DESCRIPTION
[Firebase Dynamic Links are deprecated and will shut down in August 2025](https://firebase.google.com/support/dynamic-links-faq).

This PR replaces these links with `dnd-master-58fca.web.app` links + custom protocol `wfrp-master://` which can in the future be used for Desktop apps as well. Since the domain is actually same as the domain that Dynamic links redirected to, the previously generated `wfrp.page.link` links will continue to work until Firebase pulls the plug.

In the future the plan is to use a shorter domain for the links instead of this automatically generated one but it's good enough for now and getting this out ASAP means that there will be fewer broken links out in the world.
