### PR TITLE
Increase Weapon Skill using Swarm trait

### DIFF
--- a/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/effects/CharacteristicChange.kt
+++ b/common/src/commonMain/kotlin/cz/frantisekmasa/wfrp_master/common/character/effects/CharacteristicChange.kt
@@ -113,6 +113,15 @@ open class CharacteristicChange(
                 )
             }
 
+            if (name.equals(translator.translate(Str.character_effect_swarm), ignoreCase = true)) {
+                return CharacteristicChange(
+                    plus =
+                        Stats.ZERO.copy(
+                            weaponSkill = 10,
+                        ),
+                )
+            }
+
             if (name.equals(translator.translate(Str.character_effect_tough), ignoreCase = true)) {
                 return CharacteristicChange(
                     plus =


### PR DESCRIPTION
Swarm trait was already supported but just for purposes of increasing the max Wounds. This implements the trait effects fully.